### PR TITLE
feat: centralize analytics into metrics.js and add GTM-5NBQFP8F

### DIFF
--- a/assets/js/metrics.js
+++ b/assets/js/metrics.js
@@ -1,0 +1,26 @@
+/* Leigh Services — Centralised analytics loader
+   All tracking changes should be made in this file only.
+   See: https://leigh-services.com */
+
+// Google Tag Manager
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-5NBQFP8F');
+
+// Microsoft Clarity
+(function(c,l,a,r,i,t,y){
+    c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+    t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+    y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+})(window,document,"clarity","script","x85rq1x019");
+
+// Google Analytics 4
+window.dataLayer=window.dataLayer||[];
+function gtag(){dataLayer.push(arguments);}
+gtag('js',new Date());
+gtag('config','G-HJ1PZ9E1TK');
+(function(){var s=document.createElement('script');s.async=true;
+s.src='https://www.googletagmanager.com/gtag/js?id=G-HJ1PZ9E1TK';
+document.head.appendChild(s);}());

--- a/blog.html
+++ b/blog.html
@@ -12,24 +12,12 @@
 		<meta property="og:image" content="https://leigh-services.com/images/banner.jpg" />
 		<meta name="twitter:card" content="summary_large_image" />
 		<link rel="stylesheet" href="assets/css/main.css" />
-		<!-- Microsoft Clarity -->
-		<script type="text/javascript">
-		    (function(c,l,a,r,i,t,y){
-		        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-		        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-		        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-		    })(window, document, "clarity", "script", "x85rq1x019");
-		</script>
-		<!-- Google tag (gtag.js) -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-HJ1PZ9E1TK"></script>
-		<script>
-		  window.dataLayer = window.dataLayer || [];
-		  function gtag(){dataLayer.push(arguments);}
-		  gtag('js', new Date());
-		  gtag('config', 'G-HJ1PZ9E1TK');
-		</script>
+		<script src="assets/js/metrics.js"></script>
 	</head>
 	<body class="is-preload">
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
 
 		<!-- Header -->
 			<header id="header">

--- a/case-studies.html
+++ b/case-studies.html
@@ -32,24 +32,12 @@
 				letter-spacing: 0.04em;
 			}
 		</style>
-		<!-- Microsoft Clarity -->
-		<script type="text/javascript">
-		    (function(c,l,a,r,i,t,y){
-		        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-		        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-		        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-		    })(window, document, "clarity", "script", "x85rq1x019");
-		</script>
-		<!-- Google tag (gtag.js) -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-HJ1PZ9E1TK"></script>
-		<script>
-		  window.dataLayer = window.dataLayer || [];
-		  function gtag(){dataLayer.push(arguments);}
-		  gtag('js', new Date());
-		  gtag('config', 'G-HJ1PZ9E1TK');
-		</script>
+		<script src="assets/js/metrics.js"></script>
 	</head>
 	<body class="is-preload">
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
 
 		<!-- Header -->
 			<header id="header">

--- a/certifications.html
+++ b/certifications.html
@@ -27,24 +27,12 @@
 				margin-top: 0.2em;
 			}
 		</style>
-		<!-- Microsoft Clarity -->
-		<script type="text/javascript">
-		    (function(c,l,a,r,i,t,y){
-		        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-		        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-		        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-		    })(window, document, "clarity", "script", "x85rq1x019");
-		</script>
-		<!-- Google tag (gtag.js) -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-HJ1PZ9E1TK"></script>
-		<script>
-		  window.dataLayer = window.dataLayer || [];
-		  function gtag(){dataLayer.push(arguments);}
-		  gtag('js', new Date());
-		  gtag('config', 'G-HJ1PZ9E1TK');
-		</script>
+		<script src="assets/js/metrics.js"></script>
 	</head>
 	<body class="is-preload">
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
 
 		<!-- Header -->
 			<header id="header">

--- a/contact.html
+++ b/contact.html
@@ -72,24 +72,12 @@
 				border: 0;
 			}
 		</style>
-		<!-- Microsoft Clarity -->
-		<script type="text/javascript">
-		    (function(c,l,a,r,i,t,y){
-		        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-		        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-		        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-		    })(window, document, "clarity", "script", "x85rq1x019");
-		</script>
-		<!-- Google tag (gtag.js) -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-HJ1PZ9E1TK"></script>
-		<script>
-		  window.dataLayer = window.dataLayer || [];
-		  function gtag(){dataLayer.push(arguments);}
-		  gtag('js', new Date());
-		  gtag('config', 'G-HJ1PZ9E1TK');
-		</script>
+		<script src="assets/js/metrics.js"></script>
 	</head>
 	<body class="is-preload">
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
 
 		<!-- Header -->
 			<header id="header">

--- a/elements.html
+++ b/elements.html
@@ -12,8 +12,12 @@
 		<meta name="description" content="" />
 		<meta name="keywords" content="" />
 		<link rel="stylesheet" href="assets/css/main.css" />
+		<script src="assets/js/metrics.js"></script>
 	</head>
 	<body class="is-preload">
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
 
 		<!-- Header -->
 			<header id="header">

--- a/index.html
+++ b/index.html
@@ -94,24 +94,12 @@
 				display: block;
 			}
 		</style>
-		<!-- Microsoft Clarity -->
-		<script type="text/javascript">
-		    (function(c,l,a,r,i,t,y){
-		        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-		        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-		        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-		    })(window, document, "clarity", "script", "x85rq1x019");
-		</script>
-		<!-- Google tag (gtag.js) -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-HJ1PZ9E1TK"></script>
-		<script>
-		  window.dataLayer = window.dataLayer || [];
-		  function gtag(){dataLayer.push(arguments);}
-		  gtag('js', new Date());
-		  gtag('config', 'G-HJ1PZ9E1TK');
-		</script>
+		<script src="assets/js/metrics.js"></script>
 	</head>
 	<body class="is-preload">
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
 
 		<!-- Header -->
 			<header id="header">

--- a/services.html
+++ b/services.html
@@ -38,24 +38,12 @@
 				margin-top: 1.5em;
 			}
 		</style>
-		<!-- Microsoft Clarity -->
-		<script type="text/javascript">
-		    (function(c,l,a,r,i,t,y){
-		        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-		        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-		        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-		    })(window, document, "clarity", "script", "x85rq1x019");
-		</script>
-		<!-- Google tag (gtag.js) -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-HJ1PZ9E1TK"></script>
-		<script>
-		  window.dataLayer = window.dataLayer || [];
-		  function gtag(){dataLayer.push(arguments);}
-		  gtag('js', new Date());
-		  gtag('config', 'G-HJ1PZ9E1TK');
-		</script>
+		<script src="assets/js/metrics.js"></script>
 	</head>
 	<body class="is-preload">
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
 
 		<!-- Header -->
 			<header id="header">

--- a/team.html
+++ b/team.html
@@ -133,24 +133,12 @@
 				}
 			}
 		</style>
-		<!-- Microsoft Clarity -->
-		<script type="text/javascript">
-		    (function(c,l,a,r,i,t,y){
-		        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-		        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-		        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-		    })(window, document, "clarity", "script", "x85rq1x019");
-		</script>
-		<!-- Google tag (gtag.js) -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-HJ1PZ9E1TK"></script>
-		<script>
-		  window.dataLayer = window.dataLayer || [];
-		  function gtag(){dataLayer.push(arguments);}
-		  gtag('js', new Date());
-		  gtag('config', 'G-HJ1PZ9E1TK');
-		</script>
+		<script src="assets/js/metrics.js"></script>
 	</head>
 	<body class="is-preload">
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
 
 		<!-- Header -->
 			<header id="header">

--- a/testimonials.html
+++ b/testimonials.html
@@ -12,24 +12,12 @@
 		<meta property="og:image" content="https://leigh-services.com/images/banner.jpg" />
 		<meta name="twitter:card" content="summary_large_image" />
 		<link rel="stylesheet" href="assets/css/main.css" />
-		<!-- Microsoft Clarity -->
-		<script type="text/javascript">
-		    (function(c,l,a,r,i,t,y){
-		        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-		        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-		        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-		    })(window, document, "clarity", "script", "x85rq1x019");
-		</script>
-		<!-- Google tag (gtag.js) -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-HJ1PZ9E1TK"></script>
-		<script>
-		  window.dataLayer = window.dataLayer || [];
-		  function gtag(){dataLayer.push(arguments);}
-		  gtag('js', new Date());
-		  gtag('config', 'G-HJ1PZ9E1TK');
-		</script>
+		<script src="assets/js/metrics.js"></script>
 	</head>
 	<body class="is-preload">
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
 
 		<!-- Header -->
 			<header id="header">


### PR DESCRIPTION
- Create assets/js/metrics.js as single source of truth for all tracking
- Moves Google Tag Manager (GTM-5NBQFP8F), Microsoft Clarity, and GA4 out of all 9 HTML pages and into one file
- Add GTM noscript iframe to <body> of all 9 pages
- Add metrics.js to elements.html which previously had no analytics
- Future tracking changes require editing only assets/js/metrics.js