### PR TITLE
release: Stitch-design rebuild of all 8 pages

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ This is the repository for **leigh-services.com** — a static GitHub Pages site
 
 - **Type**: Static site (plain HTML + CSS + vanilla JS). No framework, no npm, no build system locally.
 - **Domain**: leigh-services.com (CNAME → BanterBoy/leighservices master branch)
-- **Pages**: `index.html` (home), `team.html` (Meet the Team)
+- **Pages**: `index.html` (Home), `services.html` (Services), `team.html` (Meet the Team), `certifications.html` (Certifications), `case-studies.html` (Case Studies), `testimonials.html` (Testimonials), `blog.html` (Blog), `contact.html` (Contact)
 - **Styling**: SASS source lives in `assets/sass/`. Compiled output is `assets/css/main.css`.
 - **Icons**: Font Awesome 4.x (loaded from `assets/css/font-awesome.min.css`)
 - **JS**: jQuery-based, no bundler. Scripts live in `assets/js/`.
@@ -50,7 +50,7 @@ feature/xxx  →  staging  →  master (production)
 ### Pages
 
 - Every page must include the shared `<header id="header">`, `<nav id="menu">`, and `<footer id="footer">`.
-- Nav links: `index.html` (Home) and `team.html` (Meet the Team) only. Update both files if nav changes.
+- Nav links: `index.html` (Home), `services.html` (Services), `team.html` (Meet the Team), `certifications.html` (Certifications), `case-studies.html` (Case Studies), `testimonials.html` (Testimonials), `blog.html` (Blog), `contact.html` (Contact). Update all pages if nav changes.
 - Footer must include: Leigh Services name, address (63 Archer Avenue, Southend on Sea, Essex SS2 4QU), social/professional links. No email addresses or phone numbers on the public site.
 - All external links must have `target="_blank" rel="noopener noreferrer"`.
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ npm-debug.log*
 # Sass cache
 .sass-cache/
 *.css.map
+
+# Stitch redesign reference (local only)
+stitch_leigh_services_responsive_redesign/

--- a/assets/sass/components/_button.scss
+++ b/assets/sass/components/_button.scss
@@ -109,10 +109,11 @@
 				@else {
 					background-color: _palette($highlight, bg);
 					color: _palette($highlight, fg-bold) !important;
+					box-shadow: 0 0 20px rgba(0,229,255,0.35);
 
 					&:hover {
 						background-color: lighten(_palette($highlight, bg), 5);
-						box-shadow: none;
+						box-shadow: 0 0 30px rgba(0,229,255,0.55);
 
 						&:active {
 							background-color: darken(_palette($highlight, bg), 5);

--- a/assets/sass/components/_highlights.scss
+++ b/assets/sass/components/_highlights.scss
@@ -56,8 +56,19 @@
 
 		.highlights {
 			.content {
-				background: _palette($p, bg);
-				box-shadow: 0px 0px 4px 1px _palette($p, border-lt);
+				background: #0d1a2e;
+				border: 1px solid rgba(0,229,255,0.18);
+				box-shadow: 0 0 24px rgba(0,229,255,0.06);
+				transition: box-shadow 0.25s ease, border-color 0.25s ease;
+
+				&:hover {
+					border-color: rgba(0,229,255,0.45);
+					box-shadow: 0 0 32px rgba(0,229,255,0.18);
+				}
+
+				.icon {
+					color: #00e5ff;
+				}
 			}
 		}
 	}

--- a/assets/sass/components/_testimonials.scss
+++ b/assets/sass/components/_testimonials.scss
@@ -73,16 +73,15 @@
 	}
 
 	@mixin color-testimonials($p: null) {
-		$highlight: _palette($p, highlight);
-
 		.testimonials {
 			.content {
-				background: _palette($p, bg);
-				box-shadow: 0px 0px 4px 1px _palette($p, border-lt);
+				background: #0d1a2e;
+				border-left: 3px solid #00e5ff;
+				box-shadow: 0 0 20px rgba(0,229,255,0.06);
 
 				.credit {
 					strong {
-						color: _palette($highlight,bg);
+						color: #00e5ff;
 					}
 				}
 			}

--- a/assets/sass/layout/_banner.scss
+++ b/assets/sass/layout/_banner.scss
@@ -68,12 +68,12 @@
 		&:before {
 			@include vendor('transition', 'opacity 3s ease');
 			@include vendor('transition-delay', '#{_duration(banner) * 1.25}');
-			background: _palette(accent2,bg);
+			background: rgba(11,19,35,0.75);
 			content: '';
 			display: block;
 			height: 100%;
 			left: 0;
-			opacity: 0.45;
+			opacity: 1;
 			position: absolute;
 			top: 0;
 			width: 100%;

--- a/assets/sass/layout/_footer.scss
+++ b/assets/sass/layout/_footer.scss
@@ -9,7 +9,7 @@
 			text-decoration: none;
 
 			&:hover {
-				color: _palette(accent1, bg);
+				color: #00e5ff;
 			}
 		}
 

--- a/assets/sass/layout/_header.scss
+++ b/assets/sass/layout/_header.scss
@@ -19,7 +19,7 @@
 		    width: 100%;
 		    height: 100%;
 		    z-index: -1;
-		    opacity: 0.05;
+		    opacity: 0.02;
 		}
 	}
 
@@ -27,7 +27,9 @@
 		@include vendor('align-items', 'center');
 		@include vendor('display', 'flex');
 		@include vendor('justify-content', 'space-between');
-		background: _palette($accent, bg);
+		background: rgba(6,13,26,0.96);
+		backdrop-filter: blur(8px);
+		-webkit-backdrop-filter: blur(8px);
 		color: _palette($accent, fg);
 		cursor: default;
 		height: _size(header-height);
@@ -56,12 +58,13 @@
 				text-decoration: none;
 
 				&:hover {
-					color: _palette($accent, fg-bold);
+					color: #00e5ff;
 				}
 
 				&[href="#menu"] {
 					@include icon;
 					-webkit-tap-highlight-color: rgba(0,0,0,0);
+					color: #00e5ff;
 
 					&:before {
 						content: '\f0c9';

--- a/assets/sass/layout/_heading.scss
+++ b/assets/sass/layout/_heading.scss
@@ -21,16 +21,29 @@
 		width: 100%;
 
 		&:before {
-			background: linear-gradient(135deg, _palette(accent1,bg) 0%,_palette(accent2,bg) 74%);
+			background: linear-gradient(135deg, rgba(0,229,255,0.12) 0%, rgba(6,13,26,0.95) 74%);
 			content: ' ';
 			display: block;
 			height: 100%;
 			left: 0;
-			opacity: 0.6;
+			opacity: 1;
 			position: absolute;
 			top: 0;
 			width: 100%;
 			z-index: 1;
+		}
+
+		&:after {
+			content: '';
+			display: block;
+			position: absolute;
+			bottom: 0;
+			left: 0;
+			width: 100%;
+			height: 2px;
+			background: #00e5ff;
+			box-shadow: 0 0 12px rgba(0,229,255,0.8);
+			z-index: 2;
 		}
 
 		h1 {

--- a/assets/sass/layout/_menu.scss
+++ b/assets/sass/layout/_menu.scss
@@ -44,17 +44,7 @@
 						text-decoration: none;
 
 						&:hover {
-							color: _palette($accent, fg-bold);
-						}
-					}
-
-					&:first-child {
-						> a {
-							border-top: 0;
-						}
-					}
-				}
-			}
+						color: #00e5ff;
 		}
 
 		.close {

--- a/assets/sass/layout/_menu.scss
+++ b/assets/sass/layout/_menu.scss
@@ -1,94 +1,104 @@
 /* Menu */
 
-	$accent: accent2;
+$accent: accent2;
 
-	#menu {
-		@include color-typography($accent);
-		@include color-button($accent);
-		@include vendor('transform', 'translateX(#{_size(menu-width)})');
-		@include vendor('transition', (
-			'transform #{_duration(menu)} ease',
-			'box-shadow #{_duration(menu)} ease',
-			'visibility #{_duration(menu)}'
-		));
-		-webkit-overflow-scrolling: touch;
-		box-shadow: none;
-		height: 100%;
-		max-width: 80%;
-		overflow-y: auto;
-		padding: 3rem 2rem;
-		position: fixed;
-		right: 0;
-		top: 0;
-		visibility: hidden;
-		width: _size(menu-width);
-		z-index: _misc(z-index-base) + 2;
+#menu {
+@include color-typography($accent);
+@include color-button($accent);
+@include vendor('transform', 'translateX(#{_size(menu-width)})');
+@include vendor('transition', (
+'transform #{_duration(menu)} ease',
+'box-shadow #{_duration(menu)} ease',
+'visibility #{_duration(menu)}'
+));
+-webkit-overflow-scrolling: touch;
+box-shadow: none;
+height: 100%;
+max-width: 80%;
+overflow-y: auto;
+padding: 3rem 2rem;
+position: fixed;
+right: 0;
+top: 0;
+visibility: hidden;
+width: _size(menu-width);
+z-index: _misc(z-index-base) + 2;
 
-		> ul {
-			margin: 0 0 (_size(element-margin) * 0.5) 0;
+> ul {
+margin: 0 0 (_size(element-margin) * 0.5) 0;
 
-			&.links {
-				list-style: none;
-				padding: 0;
+&.links {
+list-style: none;
+padding: 0;
 
-				> li {
-					padding: 0;
+> li {
+padding: 0;
 
-					> a {
-						border: 0;
-						border-top: solid 1px _palette($accent, border);
-						color: inherit;
-						display: block;
-						letter-spacing: _size(letter-spacing-alt);
-						line-height: 3.5rem;
-						text-decoration: none;
+> a {
+border: 0;
+border-top: solid 1px _palette($accent, border);
+color: inherit;
+display: block;
+letter-spacing: _size(letter-spacing-alt);
+line-height: 3.5rem;
+text-decoration: none;
 
-						&:hover {
-						color: #00e5ff;
-		}
+&:hover {
+color: #00e5ff;
+}
+}
 
-		.close {
-			@include icon;
-			@include vendor('transition', 'color #{_duration(transition)} ease-in-out');
-			-webkit-tap-highlight-color: rgba(0,0,0,0);
-			border: 0;
-			color: _palette($accent, fg-light);
-			cursor: pointer;
-			display: block;
-			height: 3.25rem;
-			line-height: 3.25rem;
-			padding-right: 1.25rem;
-			position: absolute;
-			right: 0;
-			text-align: right;
-			top: 0;
-			vertical-align: middle;
-			width: 7rem;
+&:first-child {
+> a {
+border-top: 0;
+}
+}
+}
+}
+}
 
-			&:before {
-				content: '\f00d';
-				font-size: 1.25rem;
-			}
+.close {
+@include icon;
+@include vendor('transition', 'color #{_duration(transition)} ease-in-out');
+-webkit-tap-highlight-color: rgba(0,0,0,0);
+border: 0;
+color: _palette($accent, fg-light);
+cursor: pointer;
+display: block;
+height: 3.25rem;
+line-height: 3.25rem;
+padding-right: 1.25rem;
+position: absolute;
+right: 0;
+text-align: right;
+top: 0;
+vertical-align: middle;
+width: 7rem;
 
-			&:hover {
-				color: _palette($accent, fg-bold);
-			}
+&:before {
+content: '\f00d';
+font-size: 1.25rem;
+}
 
-			@include breakpoint('<=small') {
-				height: 4rem;
-				line-height: 4rem;
-			}
-		}
+&:hover {
+color: _palette($accent, fg-bold);
+}
 
-		@include breakpoint('<=small') {
-			padding: 2.5rem 1.75rem;
-		}
-	}
+@include breakpoint('<=small') {
+height: 4rem;
+line-height: 4rem;
+}
+}
 
-	body.is-menu-visible {
-		#menu {
-			@include vendor('transform', 'translateX(0)');
-			box-shadow: 0 0 1.5rem 0 rgba(0,0,0,0.2);
-			visibility: visible;
-		}
-	}
+@include breakpoint('<=small') {
+padding: 2.5rem 1.75rem;
+}
+}
+
+body.is-menu-visible {
+#menu {
+@include vendor('transform', 'translateX(0)');
+box-shadow: 0 0 1.5rem 0 rgba(0,0,0,0.2);
+visibility: visible;
+}
+}

--- a/assets/sass/libs/_vars.scss
+++ b/assets/sass/libs/_vars.scss
@@ -23,7 +23,7 @@
 
 // Font.
 	$font: (
-		family:				('Raleway', Arial, Helvetica, sans-serif),
+		family:				('Geist', Arial, Helvetica, sans-serif),
 		family-fixed:		('Courier New', monospace),
 		weight:				400,
 		weight-light:		300,
@@ -33,34 +33,34 @@
 
 // Palette.
 	$palette: (
-		bg:					#ffffff,
-		fg:					#444444,
-		fg-bold:			#555555,
-		fg-light:			#bbbbbb,
-		border:				rgba(0,0,0,0.25),
-		border-bg:			rgba(0,0,0,0.075),
-		border-lt:			rgba(0,0,0,0.025),
+		bg:					#0b1323,
+		fg:					#c9d4e0,
+		fg-bold:			#ffffff,
+		fg-light:			#6a7f9a,
+		border:				rgba(0,229,255,0.15),
+		border-bg:			rgba(0,229,255,0.07),
+		border-lt:			rgba(0,229,255,0.04),
 		highlight:			accent1,
 
 		accent1: (
-			bg:				#ce1b28,
-			fg:				rgba(255,255,255,0.75),
-			fg-bold:		#ffffff,
-			fg-light:		rgba(255,255,255,0.4),
-			border:			rgba(255,255,255,0.25),
-			border-bg:		rgba(255,255,255,0.075),
-			border-lt:		rgba(255,255,255,0.025),
+			bg:				#00e5ff,
+			fg:				rgba(11,19,35,0.85),
+			fg-bold:		#0b1323,
+			fg-light:		rgba(11,19,35,0.55),
+			border:			rgba(11,19,35,0.25),
+			border-bg:		rgba(11,19,35,0.075),
+			border-lt:		rgba(11,19,35,0.025),
 			highlight:		accent1
 		),
 
 		accent2: (
-			bg:				#111111,
-			fg:				rgba(255,255,255,0.5),
+			bg:				#060d1a,
+			fg:				rgba(201,212,224,0.7),
 			fg-bold:		#ffffff,
-			fg-light:		rgba(255,255,255,0.4),
-			border:			rgba(255,255,255,0.25),
-			border-bg:		rgba(255,255,255,0.075),
-			border-lt:		rgba(255,255,255,0.025),
+			fg-light:		rgba(106,127,154,0.9),
+			border:			rgba(0,229,255,0.15),
+			border-bg:		rgba(0,229,255,0.07),
+			border-lt:		rgba(0,229,255,0.04),
 			highlight:		accent1
 		)
 	);

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -6,7 +6,7 @@
 @import 'libs/grid';
 @import 'libs/flexgrid';
 @import 'font-awesome.min.css';
-@import url('https://fonts.googleapis.com/css?family=Raleway:200,300,400,500,600');
+@import url('https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&display=swap');
 
 /*
 	Industrious by TEMPLATED

--- a/blog.html
+++ b/blog.html
@@ -1,150 +1,1071 @@
-<!DOCTYPE HTML>
-<html lang="en-gb">
-	<head>
-		<title>Blog &amp; Insights | Leigh Services</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<meta name="description" content="Technical articles, guides and insights from the Leigh Services team — covering PowerShell, IT infrastructure, automation and data engineering." />
-		<meta name="keywords" content="PowerShell blog, IT infrastructure, automation, data engineering, technical articles, Luke Leigh" />
-		<meta property="og:title" content="Blog &amp; Insights | Leigh Services" />
-		<meta property="og:description" content="Technical articles and insights on PowerShell, infrastructure automation and data engineering." />
-		<meta property="og:url" content="https://leigh-services.com/blog.html" />
-		<meta property="og:image" content="https://leigh-services.com/images/banner.jpg" />
-		<meta property="og:type" content="website" />
-		<meta property="og:site_name" content="Leigh Services" />
-		<meta http-equiv="content-language" content="en-gb" />
-		<link rel="canonical" href="https://leigh-services.com/blog.html" />
-		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Blog &amp; Insights | Leigh Services" />
-		<meta name="twitter:description" content="Technical articles and insights on PowerShell, infrastructure automation and data engineering." />
-		<meta name="twitter:image" content="https://leigh-services.com/images/banner.jpg" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<script src="assets/js/metrics.js"></script>
-	</head>
-	<body class="is-preload">
-		<!-- Google Tag Manager (noscript) -->
-		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-		<!-- End Google Tag Manager (noscript) -->
+<!doctype html>
+<html class="dark" lang="en-gb">
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Blog &amp; Insights | Leigh Services</title>
+    <meta
+      name="description"
+      content="Technical articles, guides and insights from the Leigh Services team — covering PowerShell, IT infrastructure, automation and data engineering."
+    />
+    <meta
+      name="keywords"
+      content="PowerShell blog, IT infrastructure, automation, data engineering, technical articles, Luke Leigh"
+    />
+    <meta property="og:title" content="Blog &amp; Insights | Leigh Services" />
+    <meta
+      property="og:description"
+      content="Technical articles and insights on PowerShell, infrastructure automation and data engineering."
+    />
+    <meta property="og:url" content="https://leigh-services.com/blog.html" />
+    <meta
+      property="og:image"
+      content="https://leigh-services.com/images/banner.jpg"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Leigh Services" />
+    <meta http-equiv="content-language" content="en-gb" />
+    <link rel="canonical" href="https://leigh-services.com/blog.html" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Blog &amp; Insights | Leigh Services" />
+    <meta
+      name="twitter:description"
+      content="Technical articles and insights on PowerShell, infrastructure automation and data engineering."
+    />
+    <meta
+      name="twitter:image"
+      content="https://leigh-services.com/images/banner.jpg"
+    />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&amp;family=Geist:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <script src="assets/js/metrics.js"></script>
+    <script id="tailwind-config">
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            colors: {
+              "surface-container-low": "#131c2b",
+              "outline-variant": "#3b494c",
+              "on-error": "#690005",
+              "on-tertiary-fixed": "#001945",
+              "surface-container-lowest": "#060e1d",
+              "on-background": "#dbe2f8",
+              "error-container": "#93000a",
+              "on-secondary": "#1b247f",
+              "surface-tint": "#00daf3",
+              "tertiary-container": "#bfd0ff",
+              "primary-container": "#00e5ff",
+              "on-tertiary-fixed-variant": "#00429c",
+              "on-secondary-fixed-variant": "#343d96",
+              "inverse-surface": "#dbe2f8",
+              "inverse-primary": "#006875",
+              "surface-container": "#18202f",
+              surface: "#0b1323",
+              "on-primary-container": "#00626e",
+              "on-primary-fixed": "#001f24",
+              error: "#ffb4ab",
+              "surface-container-high": "#222a3a",
+              "secondary-fixed": "#e0e0ff",
+              "on-secondary-container": "#a8afff",
+              "tertiary-fixed-dim": "#b0c6ff",
+              "secondary-container": "#343d96",
+              "primary-fixed-dim": "#00daf3",
+              tertiary: "#e8ecff",
+              "on-tertiary-container": "#2455af",
+              "on-primary-fixed-variant": "#004f58",
+              "on-secondary-fixed": "#000767",
+              primary: "#c3f5ff",
+              background: "#0b1323",
+              "on-tertiary": "#002d6f",
+              "on-primary": "#00363d",
+              "on-error-container": "#ffdad6",
+              "inverse-on-surface": "#283041",
+              "surface-variant": "#2d3546",
+              "surface-container-highest": "#2d3546",
+              secondary: "#bdc2ff",
+              outline: "#849396",
+              "on-surface-variant": "#bac9cc",
+              "surface-bright": "#31394a",
+              "primary-fixed": "#9cf0ff",
+              "tertiary-fixed": "#d9e2ff",
+              "surface-dim": "#0b1323",
+              "on-surface": "#dbe2f8",
+              "secondary-fixed-dim": "#bdc2ff",
+            },
+            borderRadius: {
+              DEFAULT: "0.125rem",
+              lg: "0.25rem",
+              xl: "0.5rem",
+              full: "0.75rem",
+            },
+            spacing: {
+              xs: "4px",
+              margin: "24px",
+              lg: "24px",
+              xl: "40px",
+              gutter: "16px",
+              base: "4px",
+              sm: "8px",
+              md: "16px",
+            },
+            fontFamily: {
+              "headline-lg-mobile": ["Geist"],
+              "title-md": ["Geist"],
+              "label-sm": ["JetBrains Mono"],
+              "headline-lg": ["Geist"],
+              "body-sm": ["Geist"],
+              "label-md": ["JetBrains Mono"],
+              "body-lg": ["Geist"],
+              "display-lg": ["Geist"],
+            },
+            fontSize: {
+              "headline-lg-mobile": [
+                "24px",
+                { lineHeight: "32px", fontWeight: "600" },
+              ],
+              "title-md": ["20px", { lineHeight: "28px", fontWeight: "500" }],
+              "label-sm": [
+                "10px",
+                {
+                  lineHeight: "14px",
+                  letterSpacing: "0.05em",
+                  fontWeight: "500",
+                },
+              ],
+              "headline-lg": [
+                "32px",
+                { lineHeight: "40px", fontWeight: "600" },
+              ],
+              "body-sm": ["14px", { lineHeight: "20px", fontWeight: "400" }],
+              "label-md": [
+                "12px",
+                {
+                  lineHeight: "16px",
+                  letterSpacing: "0.05em",
+                  fontWeight: "500",
+                },
+              ],
+              "body-lg": ["16px", { lineHeight: "24px", fontWeight: "400" }],
+              "display-lg": [
+                "48px",
+                {
+                  lineHeight: "56px",
+                  letterSpacing: "-0.02em",
+                  fontWeight: "700",
+                },
+              ],
+            },
+          },
+        },
+      };
+    </script>
+    <style>
+      .material-symbols-outlined {
+        font-variation-settings:
+          "FILL" 0,
+          "wght" 400,
+          "GRAD" 0,
+          "opsz" 24;
+      }
+      .glass-card {
+        background: rgba(24, 32, 47, 0.7);
+        backdrop-filter: blur(12px);
+        border: 1px solid rgba(0, 229, 255, 0.1);
+      }
+      .hover-glow:hover {
+        box-shadow: 0 0 15px rgba(0, 229, 255, 0.3);
+      }
+    </style>
+  </head>
+  <body
+    class="bg-background text-on-background font-body-lg selection:bg-primary-container selection:text-on-primary-container"
+  >
+    <!-- Google Tag Manager (noscript) -->
+    <noscript
+      ><iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden"
+      ></iframe
+    ></noscript>
 
-		<!-- Header -->
-			<header id="header">
-				<a class="logo" href="index.html">Leigh Services</a>
-				<nav>
-					<a href="#menu">Menu</a>
-				</nav>
-			</header>
+    <!-- Header -->
+    <header
+      class="bg-surface-container-lowest border-b border-outline-variant sticky top-0 z-50"
+    >
+      <nav class="px-lg py-md w-full max-w-7xl mx-auto">
+        <div class="flex justify-between items-center">
+          <a
+            class="font-headline-lg text-headline-lg font-bold text-primary-fixed-dim tracking-tight"
+            href="index.html"
+            >Leigh Services</a
+          >
+          <div class="hidden md:flex gap-lg items-center">
+            <a
+              class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+              href="index.html"
+              >Home</a
+            >
+            <a
+              class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+              href="services.html"
+              >Services</a
+            >
+            <a
+              class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+              href="team.html"
+              >Meet the Team</a
+            >
+            <a
+              class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+              href="certifications.html"
+              >Certifications</a
+            >
+            <a
+              class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+              href="case-studies.html"
+              >Case Studies</a
+            >
+            <a
+              class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+              href="testimonials.html"
+              >Testimonials</a
+            >
+            <a
+              class="text-primary-fixed-dim font-bold border-b-2 border-primary-fixed-dim pb-1"
+              href="blog.html"
+              >Blog</a
+            >
+            <a
+              class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+              href="contact.html"
+              >Contact</a
+            >
+            <a
+              class="ml-md bg-primary-container text-on-primary-fixed px-md py-sm rounded font-bold hover:opacity-80 transition-all"
+              href="contact.html"
+              >Consultation</a
+            >
+          </div>
+          <!-- Mobile Menu Toggle -->
+          <button
+            class="md:hidden text-primary-fixed-dim"
+            onclick="
+              document.getElementById('mobile-menu').classList.toggle('hidden')
+            "
+            aria-label="Open menu"
+          >
+            <span class="material-symbols-outlined">menu</span>
+          </button>
+        </div>
+      </nav>
+    </header>
 
-		<!-- Nav -->
-			<nav id="menu">
-				<ul class="links">
-					<li><a href="index.html">Home</a></li>
-					<li><a href="services.html">Services</a></li>
-					<li><a href="team.html">Meet the Team</a></li>
-					<li><a href="certifications.html">Certifications</a></li>
-					<li><a href="case-studies.html">Case Studies</a></li>
-					<li><a href="testimonials.html">Testimonials</a></li>
-					<li><a href="blog.html">Blog</a></li>
-					<li><a href="contact.html">Contact</a></li>
-				</ul>
-			</nav>
+    <!-- Mobile Menu -->
+    <div
+      class="hidden md:hidden fixed inset-0 z-[110] bg-surface-container-lowest p-lg"
+      id="mobile-menu"
+    >
+      <div class="flex flex-col gap-md">
+        <div class="flex justify-between items-center mb-xl">
+          <span
+            class="font-headline-lg-mobile text-headline-lg-mobile text-primary-fixed-dim"
+            >Leigh Services</span
+          >
+          <button
+            onclick="
+              document.getElementById('mobile-menu').classList.add('hidden')
+            "
+            aria-label="Close menu"
+          >
+            <span class="material-symbols-outlined">close</span>
+          </button>
+        </div>
+        <a class="text-title-md py-sm" href="index.html">Home</a>
+        <a class="text-title-md py-sm" href="services.html">Services</a>
+        <a class="text-title-md py-sm" href="team.html">Meet the Team</a>
+        <a class="text-title-md py-sm" href="certifications.html"
+          >Certifications</a
+        >
+        <a class="text-title-md py-sm" href="case-studies.html">Case Studies</a>
+        <a class="text-title-md py-sm" href="testimonials.html">Testimonials</a>
+        <a
+          class="text-title-md py-sm text-primary-fixed-dim font-bold"
+          href="blog.html"
+          >Blog</a
+        >
+        <a class="text-title-md py-sm" href="contact.html">Contact</a>
+        <a
+          class="mt-md bg-primary-container text-on-primary-fixed text-center px-md py-md rounded font-bold"
+          href="contact.html"
+          >Consultation</a
+        >
+      </div>
+    </div>
 
-		<!-- Heading -->
-			<div id="heading">
-				<h1>Blog &amp; Insights</h1>
-			</div>
+    <main class="w-full">
+      <!-- Hero Section -->
+      <section
+        class="relative h-[409px] min-h-[400px] flex items-center overflow-hidden border-b border-outline-variant"
+      >
+        <div class="absolute inset-0 z-0">
+          <div
+            class="absolute inset-0 bg-gradient-to-b from-background/0 via-background/20 to-background"
+          ></div>
+        </div>
+        <div class="relative z-10 max-w-7xl mx-auto px-lg w-full">
+          <div class="max-w-2xl">
+            <span
+              class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest bg-primary-container/10 px-sm py-xs mb-md inline-block"
+              >Insights &amp; Analysis</span
+            >
+            <h1
+              class="font-display-lg text-display-lg mb-md leading-none text-primary"
+            >
+              Blog &amp; Insights.
+            </h1>
+            <p class="font-body-lg text-on-surface-variant max-w-xl">
+              Guides, tooling write-ups and insights from the Leigh Services
+              team. Full posts are published on
+              <a
+                class="text-primary-fixed-dim hover:underline"
+                href="https://blog.lukeleigh.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Luke's Blog</a
+              >
+              — this page curates selected highlights.
+            </p>
+          </div>
+        </div>
+      </section>
 
-		<!-- Blog Posts -->
-			<section class="wrapper">
-				<div class="inner">
-					<header class="special">
-						<h2>Technical Articles</h2>
-						<p>Guides, tooling write-ups and insights from the Leigh Services team. Full posts are published on <a href="https://blog.lukeleigh.com" target="_blank" rel="noopener noreferrer">Luke's Blog</a> — this page curates selected highlights.</p>
-					</header>
-					<div class="highlights">
+      <!-- Main Content Grid -->
+      <section class="max-w-7xl mx-auto px-lg py-xl">
+        <div class="grid grid-cols-1 lg:grid-cols-12 gap-lg">
+          <!-- Featured & Feed (8 cols) -->
+          <div class="lg:col-span-8 space-y-xl">
+            <!-- Featured Article: The Blinking Cursor Problem -->
+            <article
+              class="glass-card rounded-xl overflow-hidden group hover-glow transition-all"
+            >
+              <div class="grid md:grid-cols-2">
+                <div
+                  class="relative h-64 md:h-auto overflow-hidden bg-primary-container/10 flex items-center justify-center"
+                >
+                  <span
+                    class="material-symbols-outlined text-primary-fixed-dim"
+                    style="font-size: 96px"
+                    >smart_toy</span
+                  >
+                  <div class="absolute top-md left-md">
+                    <span
+                      class="font-label-sm text-label-sm bg-primary-fixed-dim text-on-primary-fixed px-sm py-xs rounded"
+                      >FEATURED</span
+                    >
+                  </div>
+                </div>
+                <div class="p-xl flex flex-col justify-center">
+                  <div class="flex items-center gap-sm mb-md text-outline">
+                    <span class="font-label-sm text-label-sm"
+                      >AI &middot; PRODUCTIVITY</span
+                    >
+                    <span class="w-1 h-1 bg-outline rounded-full"></span>
+                    <span class="font-label-sm text-label-sm">10 MIN READ</span>
+                  </div>
+                  <h2
+                    class="font-headline-lg text-headline-lg mb-md group-hover:text-primary-fixed-dim transition-colors"
+                  >
+                    The Blinking Cursor Problem &mdash; Getting More Out of A.I.
+                  </h2>
+                  <p class="text-on-surface-variant font-body-lg mb-xl">
+                    Most people treat A.I. like a search engine &mdash; type
+                    three words, hit enter, wonder why it's rubbish. It isn't
+                    the tool that's the problem. A practical guide to using AI
+                    properly as an engineer.
+                  </p>
+                  <div class="mt-auto flex items-center justify-between">
+                    <div class="flex items-center gap-sm">
+                      <div
+                        class="w-10 h-10 rounded-full bg-surface-container-high flex items-center justify-center border border-outline-variant"
+                      >
+                        <span
+                          class="material-symbols-outlined text-primary-fixed-dim"
+                          >person</span
+                        >
+                      </div>
+                      <div>
+                        <div class="font-label-md text-label-md">
+                          Luke Leigh
+                        </div>
+                        <div class="font-label-sm text-label-sm text-outline">
+                          blog.lukeleigh.com
+                        </div>
+                      </div>
+                    </div>
+                    <a
+                      class="text-primary-fixed-dim flex items-center gap-xs font-bold hover:gap-sm transition-all"
+                      href="https://blog.lukeleigh.com/blog/the-blinking-cursor-problem/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Read More
+                      <span class="material-symbols-outlined text-sm"
+                        >arrow_forward</span
+                      >
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </article>
 
-						<section>
-							<div class="content">
-								<header>
-									<a href="https://blog.lukeleigh.com" target="_blank" rel="noopener noreferrer" class="icon fa-terminal"><span class="label">PowerShell</span></a>
-									<h3>PowerShell Scripting &amp; Automation</h3>
-								</header>
-								<p>Articles covering PowerShell best practices, module development, toolmaking and real-world automation patterns — from simple one-liners to production-grade tooling published on the PowerShell Gallery.</p>
-								<p><a href="https://blog.lukeleigh.com" target="_blank" rel="noopener noreferrer">Read on Luke's Blog &rarr;</a></p>
-							</div>
-						</section>
+            <!-- Bento Grid for Articles -->
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-lg">
+              <!-- Article: DigitalTAK Part 4 -->
+              <article
+                class="glass-card rounded-xl p-lg flex flex-col hover-glow transition-all"
+              >
+                <div class="mb-md">
+                  <span
+                    class="font-label-sm text-label-sm text-primary-fixed-dim uppercase"
+                    >DigitalTAK &middot; PowerShell</span
+                  >
+                </div>
+                <h3 class="font-title-md text-title-md mb-sm">
+                  DigitalTAK, Part 4 &mdash; Running the Deployment
+                </h3>
+                <p
+                  class="text-on-surface-variant font-body-sm mb-xl line-clamp-3"
+                >
+                  Prerequisites, one command, twenty minutes, a working TAK
+                  Server. A walkthrough of Deploy-TAKServer.ps1 covering what
+                  actually happens, what you need before you start, and what you
+                  get at the end.
+                </p>
+                <div
+                  class="mt-auto pt-md border-t border-outline-variant flex items-center justify-between"
+                >
+                  <span class="font-label-sm text-label-sm text-outline"
+                    >5 MIN READ</span
+                  >
+                  <a
+                    class="w-8 h-8 rounded-full border border-outline-variant flex items-center justify-center hover:bg-primary-fixed-dim hover:text-on-primary-fixed transition-colors"
+                    href="https://blog.lukeleigh.com/blog/digitaltak-part4-running-the-deployment/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="Read: DigitalTAK Part 4"
+                  >
+                    <span class="material-symbols-outlined text-sm"
+                      >north_east</span
+                    >
+                  </a>
+                </div>
+              </article>
 
-						<section>
-							<div class="content">
-								<header>
-									<a href="https://blog.lukeleigh.com" target="_blank" rel="noopener noreferrer" class="icon fa-server"><span class="label">Infrastructure</span></a>
-									<h3>IT Infrastructure &amp; Microsoft 365</h3>
-								</header>
-								<p>Practical guides on Windows Server, Active Directory, Exchange Online, Azure and Microsoft 365 administration — including migration patterns, troubleshooting and real-world configuration examples.</p>
-								<p><a href="https://blog.lukeleigh.com" target="_blank" rel="noopener noreferrer">Read on Luke's Blog &rarr;</a></p>
-							</div>
-						</section>
+              <!-- Article: UserAdminModule -->
+              <article
+                class="glass-card rounded-xl p-lg flex flex-col hover-glow transition-all"
+              >
+                <div class="mb-md">
+                  <span
+                    class="font-label-sm text-label-sm text-primary-fixed-dim uppercase"
+                    >PowerShell &middot; Modules</span
+                  >
+                </div>
+                <h3 class="font-title-md text-title-md mb-sm">
+                  Stop Dot-Sourcing. Start Managing.
+                </h3>
+                <p
+                  class="text-on-surface-variant font-body-sm mb-xl line-clamp-3"
+                >
+                  Introducing UserAdminModule &mdash; a PowerShell module built
+                  to solve a problem quietly ignored for years: a $PROFILE full
+                  of dot-sourcing held together by hope.
+                </p>
+                <div
+                  class="mt-auto pt-md border-t border-outline-variant flex items-center justify-between"
+                >
+                  <span class="font-label-sm text-label-sm text-outline"
+                    >5 MIN READ</span
+                  >
+                  <a
+                    class="w-8 h-8 rounded-full border border-outline-variant flex items-center justify-center hover:bg-primary-fixed-dim hover:text-on-primary-fixed transition-colors"
+                    href="https://blog.lukeleigh.com/blog/stop-dot-sourcing-start-managing-introducing-useradminmodule/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="Read: UserAdminModule"
+                  >
+                    <span class="material-symbols-outlined text-sm"
+                      >north_east</span
+                    >
+                  </a>
+                </div>
+              </article>
 
-						<section>
-							<div class="content">
-								<header>
-									<a href="https://blog.lukeleigh.com" target="_blank" rel="noopener noreferrer" class="icon fa-shield"><span class="label">Security</span></a>
-									<h3>Security, Compliance &amp; Hardening</h3>
-								</header>
-								<p>Write-ups on PCI DSS compliance delivery, Active Directory hardening, firewall management and security tooling — covering what we have encountered and how we have addressed it in practice.</p>
-								<p><a href="https://blog.lukeleigh.com" target="_blank" rel="noopener noreferrer">Read on Luke's Blog &rarr;</a></p>
-							</div>
-						</section>
+              <!-- Article: PSReadLine history -->
+              <article
+                class="glass-card rounded-xl p-lg flex flex-col hover-glow transition-all"
+              >
+                <div class="mb-md">
+                  <span
+                    class="font-label-sm text-label-sm text-primary-fixed-dim uppercase"
+                    >PowerShell &middot; PSReadLine</span
+                  >
+                </div>
+                <h3 class="font-title-md text-title-md mb-sm">
+                  Your PowerShell History is Smarter Than You Think
+                </h3>
+                <p
+                  class="text-on-surface-variant font-body-sm mb-xl line-clamp-3"
+                >
+                  PSReadLine has been quietly saving your command history for
+                  years. Here are the bits most admins never get around to
+                  discovering &mdash; including the ones that genuinely save
+                  hours.
+                </p>
+                <div
+                  class="mt-auto pt-md border-t border-outline-variant flex items-center justify-between"
+                >
+                  <span class="font-label-sm text-label-sm text-outline"
+                    >4 MIN READ</span
+                  >
+                  <a
+                    class="w-8 h-8 rounded-full border border-outline-variant flex items-center justify-center hover:bg-primary-fixed-dim hover:text-on-primary-fixed transition-colors"
+                    href="https://blog.lukeleigh.com/blog/your-powershell-history-is-smarter-than-you-think/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="Read: PowerShell History"
+                  >
+                    <span class="material-symbols-outlined text-sm"
+                      >north_east</span
+                    >
+                  </a>
+                </div>
+              </article>
 
-					</div>
+              <!-- Article: New-Shell -->
+              <article
+                class="glass-card rounded-xl p-lg flex flex-col hover-glow transition-all"
+              >
+                <div class="mb-md">
+                  <span
+                    class="font-label-sm text-label-sm text-primary-fixed-dim uppercase"
+                    >PowerShell &middot; Productivity</span
+                  >
+                </div>
+                <h3 class="font-title-md text-title-md mb-sm">
+                  New-Shell &mdash; Stop Right-Clicking, Start Scripting
+                </h3>
+                <p
+                  class="text-on-surface-variant font-body-sm mb-xl line-clamp-3"
+                >
+                  One function, five ways to open a PowerShell session.
+                  Standard, elevated, as a different user, in Windows Terminal,
+                  elevated in Windows Terminal &mdash; without touching a mouse.
+                </p>
+                <div
+                  class="mt-auto pt-md border-t border-outline-variant flex items-center justify-between"
+                >
+                  <span class="font-label-sm text-label-sm text-outline"
+                    >4 MIN READ</span
+                  >
+                  <a
+                    class="w-8 h-8 rounded-full border border-outline-variant flex items-center justify-center hover:bg-primary-fixed-dim hover:text-on-primary-fixed transition-colors"
+                    href="https://blog.lukeleigh.com/blog/new-shell-stop-right-clicking-start-scripting/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="Read: New-Shell"
+                  >
+                    <span class="material-symbols-outlined text-sm"
+                      >north_east</span
+                    >
+                  </a>
+                </div>
+              </article>
 
-					<div style="text-align:center; margin-top:3em;">
-						<a href="https://blog.lukeleigh.com" target="_blank" rel="noopener noreferrer" class="button primary">Visit the Full Blog</a>
-					</div>
-				</div>
-			</section>
+              <!-- Article: Get-GistIframe (full width) -->
+              <article
+                class="glass-card rounded-xl p-lg flex flex-col hover-glow transition-all md:col-span-2"
+              >
+                <div class="mb-md flex items-center justify-between">
+                  <span
+                    class="font-label-sm text-label-sm text-primary-fixed-dim uppercase"
+                    >PowerShell &middot; Scripting</span
+                  >
+                  <span class="font-label-sm text-label-sm text-outline"
+                    >5 MIN READ</span
+                  >
+                </div>
+                <h3 class="font-title-md text-title-md mb-sm">
+                  Get-GistIframe &mdash; Embedding GitHub Gists Without the
+                  Liquid Nonsense
+                </h3>
+                <p
+                  class="text-on-surface-variant font-body-sm mb-xl line-clamp-2"
+                >
+                  A small but genuinely useful utility that converts a GitHub
+                  Gist script tag into a properly styled iframe and copies it to
+                  your clipboard.
+                </p>
+                <div
+                  class="mt-auto pt-md border-t border-outline-variant flex items-center justify-between"
+                >
+                  <a
+                    class="text-primary-fixed-dim flex items-center gap-xs font-bold hover:gap-sm transition-all"
+                    href="https://blog.lukeleigh.com/blog/get-gistiframe/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Read on the blog
+                    <span class="material-symbols-outlined text-sm"
+                      >arrow_forward</span
+                    >
+                  </a>
+                  <a
+                    class="font-label-sm text-label-sm text-outline hover:text-primary-fixed-dim transition-colors"
+                    href="https://blog.lukeleigh.com/posts/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Browse all posts &rarr;</a
+                  >
+                </div>
+              </article>
+            </div>
+          </div>
 
-		<!-- Footer -->
-			<footer id="footer">
-				<div class="inner">
-					<div class="content">
-						<section>
-							<h3>Leigh Services</h3>
-							<p>Expert IT Infrastructure, Automation and Data Engineering consulting based in Southend-on-Sea, Essex. Serving clients across the UK and internationally.</p>
-							<p>63 Archer Avenue, Southend on Sea, Essex SS2 4QU</p>
-						</section>
-						<section>
-							<h4>Services</h4>
-							<ul class="alt">
-								<li><a href="services.html#it-infrastructure">IT Infrastructure</a></li>
-								<li><a href="services.html#powershell-automation">PowerShell &amp; Automation</a></li>
-								<li><a href="services.html#cloud-solutions">Cloud Solutions</a></li>
-								<li><a href="services.html#data-engineering">Data Engineering</a></li>
-								<li><a href="services.html#security-compliance">Security &amp; Compliance</a></li>
-								<li><a href="services.html#devsecops">DevSecOps</a></li>
-							</ul>
-						</section>
-						<section>
-							<h4>Connect</h4>
-							<ul class="plain">
-								<li><a href="https://www.linkedin.com/in/lukeleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>Luke on LinkedIn</a></li>
-								<li><a href="https://www.linkedin.com/in/markleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>Mark on LinkedIn</a></li>
-								<li><a href="https://github.com/BanterBoy" target="_blank" rel="noopener noreferrer"><i class="icon fa-github">&nbsp;</i>GitHub (BanterBoy)</a></li>
-								<li><a href="https://blog.lukeleigh.com" target="_blank" rel="noopener noreferrer"><i class="icon fa-rss">&nbsp;</i>Luke's Blog</a></li>
-							</ul>
-						</section>
-					</div>
-					<div class="copyright">
-						&copy; 2024&ndash;2026 Leigh IT Services Ltd. All rights reserved.
-					</div>
-				</div>
-			</footer>
+          <!-- Sidebar (4 cols) -->
+          <aside class="lg:col-span-4 space-y-lg">
+            <!-- Search & Filter -->
+            <div
+              class="bg-surface-container rounded-xl p-lg border border-outline-variant"
+            >
+              <h4
+                class="font-label-md text-label-md text-primary-fixed-dim mb-md uppercase"
+              >
+                Search Insights
+              </h4>
+              <div class="relative">
+                <input
+                  class="w-full bg-background border border-outline-variant rounded-lg px-md py-sm text-body-sm focus:border-primary-fixed-dim focus:ring-1 focus:ring-primary-fixed-dim transition-all"
+                  placeholder="Keywords, tech stack..."
+                  type="text"
+                  aria-label="Search insights"
+                />
+                <span
+                  class="material-symbols-outlined absolute right-md top-1/2 -translate-y-1/2 text-outline pointer-events-none"
+                  aria-hidden="true"
+                  >search</span
+                >
+              </div>
+            </div>
 
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+            <!-- Newsletter -->
+            <div
+              class="bg-primary-container/10 border border-primary-container/20 rounded-xl p-lg"
+            >
+              <h4
+                class="font-title-md text-title-md mb-sm text-primary-fixed-dim"
+              >
+                Infrastructure Newsletter
+              </h4>
+              <p class="font-body-sm text-on-surface-variant mb-md">
+                Get monthly technical breakdowns and security alerts delivered
+                to your inbox.
+              </p>
+              <form class="space-y-sm" action="#" method="post">
+                <input
+                  class="w-full bg-surface-container-lowest border border-outline-variant rounded-lg px-md py-sm text-body-sm focus:border-primary-fixed-dim outline-none"
+                  placeholder="email@enterprise.com"
+                  type="email"
+                  aria-label="Email address"
+                />
+                <button
+                  type="submit"
+                  class="w-full bg-primary-fixed-dim text-on-primary-fixed font-bold py-sm rounded-lg hover:opacity-90 transition-opacity"
+                >
+                  Subscribe
+                </button>
+              </form>
+              <p class="font-label-sm text-label-sm text-outline mt-sm">
+                Zero spam. Hard technical data only.
+              </p>
+            </div>
 
-	</body>
+            <!-- Topics Cloud -->
+            <div
+              class="bg-surface-container rounded-xl p-lg border border-outline-variant"
+            >
+              <h4
+                class="font-label-md text-label-md text-primary-fixed-dim mb-md uppercase"
+              >
+                Trending Topics
+              </h4>
+              <div class="flex flex-wrap gap-sm">
+                <a
+                  class="font-label-sm text-label-sm bg-surface-container-high px-sm py-xs rounded-full border border-outline-variant hover:border-primary-fixed-dim transition-colors"
+                  href="https://blog.lukeleigh.com/categories/#powershell"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >PowerShell</a
+                >
+                <a
+                  class="font-label-sm text-label-sm bg-surface-container-high px-sm py-xs rounded-full border border-outline-variant hover:border-primary-fixed-dim transition-colors"
+                  href="https://blog.lukeleigh.com/categories/#digitaltak"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >DigitalTAK</a
+                >
+                <a
+                  class="font-label-sm text-label-sm bg-surface-container-high px-sm py-xs rounded-full border border-outline-variant hover:border-primary-fixed-dim transition-colors"
+                  href="https://blog.lukeleigh.com/tags/#modules"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >Modules</a
+                >
+                <a
+                  class="font-label-sm text-label-sm bg-surface-container-high px-sm py-xs rounded-full border border-outline-variant hover:border-primary-fixed-dim transition-colors"
+                  href="https://blog.lukeleigh.com/categories/#ai"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >AI</a
+                >
+                <a
+                  class="font-label-sm text-label-sm bg-surface-container-high px-sm py-xs rounded-full border border-outline-variant hover:border-primary-fixed-dim transition-colors"
+                  href="https://blog.lukeleigh.com/tags/#scripting"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >Scripting</a
+                >
+                <a
+                  class="font-label-sm text-label-sm bg-surface-container-high px-sm py-xs rounded-full border border-outline-variant hover:border-primary-fixed-dim transition-colors"
+                  href="https://blog.lukeleigh.com/tags/#security"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >Security</a
+                >
+                <a
+                  class="font-label-sm text-label-sm bg-surface-container-high px-sm py-xs rounded-full border border-outline-variant hover:border-primary-fixed-dim transition-colors"
+                  href="https://blog.lukeleigh.com/tags/#admin"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >Admin</a
+                >
+                <a
+                  class="font-label-sm text-label-sm bg-surface-container-high px-sm py-xs rounded-full border border-outline-variant hover:border-primary-fixed-dim transition-colors"
+                  href="https://blog.lukeleigh.com/tags/#tak"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >TAK</a
+                >
+              </div>
+            </div>
+
+            <!-- Must Reads -->
+            <div
+              class="bg-surface-container rounded-xl p-lg border border-outline-variant"
+            >
+              <h4
+                class="font-label-md text-label-md text-primary-fixed-dim mb-md uppercase"
+              >
+                Must Reads
+              </h4>
+              <div class="space-y-md">
+                <a
+                  class="group block"
+                  href="https://blog.lukeleigh.com/blog/digitaltak-part1-what-is-tak/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <div class="font-label-sm text-label-sm text-outline mb-xs">
+                    01 / SERIES
+                  </div>
+                  <div
+                    class="font-body-lg text-body-lg group-hover:text-primary-fixed-dim transition-colors"
+                  >
+                    DigitalTAK, Part 1 &mdash; What on Earth is TAK?
+                  </div>
+                </a>
+                <a
+                  class="group block"
+                  href="https://blog.lukeleigh.com/blog/the-powershell-profile/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <div class="font-label-sm text-label-sm text-outline mb-xs">
+                    02 / GUIDE
+                  </div>
+                  <div
+                    class="font-body-lg text-body-lg group-hover:text-primary-fixed-dim transition-colors"
+                  >
+                    The PowerShell Profile &mdash; under-utilised admin
+                    assistant
+                  </div>
+                </a>
+                <a
+                  class="group block"
+                  href="https://blog.lukeleigh.com/blog/60-seconds-with-luke-leigh/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <div class="font-label-sm text-label-sm text-outline mb-xs">
+                    03 / PROFILE
+                  </div>
+                  <div
+                    class="font-body-lg text-body-lg group-hover:text-primary-fixed-dim transition-colors"
+                  >
+                    60 Seconds With&hellip; Luke Leigh
+                  </div>
+                </a>
+                <a
+                  class="group block pt-md border-t border-outline-variant"
+                  href="https://blog.lukeleigh.com/posts/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <div
+                    class="font-label-sm text-label-sm text-primary-fixed-dim mb-xs uppercase tracking-wider"
+                  >
+                    Browse all posts &rarr;
+                  </div>
+                  <div
+                    class="font-body-sm text-body-sm text-on-surface-variant"
+                  >
+                    Full archive on blog.lukeleigh.com
+                  </div>
+                </a>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <!-- CTA Band -->
+      <section
+        class="bg-surface-container-high py-xl border-y border-outline-variant overflow-hidden relative"
+      >
+        <div class="max-w-7xl mx-auto px-lg relative z-10 text-center">
+          <h2 class="font-display-lg text-display-lg mb-md text-primary">
+            Read more on the blog.
+          </h2>
+          <p
+            class="font-body-lg text-on-surface-variant max-w-2xl mx-auto mb-xl"
+          >
+            Full technical articles, walkthroughs and PowerShell tooling are
+            published on Luke's blog — or get in touch if you need engineering
+            help on your own infrastructure.
+          </p>
+          <div class="flex flex-col sm:flex-row gap-md justify-center">
+            <a
+              class="bg-primary-container text-on-primary-fixed px-xl py-md rounded font-bold hover:scale-105 transition-transform flex items-center justify-center gap-sm"
+              href="https://blog.lukeleigh.com"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Visit the Full Blog
+              <span class="material-symbols-outlined">rocket_launch</span>
+            </a>
+            <a
+              class="border border-outline-variant text-on-surface px-xl py-md rounded font-bold hover:bg-surface-container-highest transition-colors"
+              href="contact.html"
+            >
+              Get in Touch
+            </a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-surface-container-lowest border-t border-outline-variant">
+      <div
+        class="grid grid-cols-1 md:grid-cols-4 gap-xl px-lg py-xl max-w-7xl mx-auto"
+      >
+        <div>
+          <div
+            class="font-title-md text-title-md font-bold text-primary-fixed-dim mb-md"
+          >
+            Leigh Services
+          </div>
+          <p
+            class="font-body-sm text-body-sm text-on-surface-variant leading-relaxed"
+          >
+            Expert IT Infrastructure, Automation and Data Engineering consulting
+            based in Southend-on-Sea, Essex. Serving clients across the UK and
+            internationally.
+          </p>
+          <p
+            class="font-body-sm text-body-sm text-on-surface-variant mt-md italic"
+          >
+            63 Archer Avenue, Southend on Sea, Essex SS2 4QU
+          </p>
+        </div>
+        <div>
+          <div
+            class="font-label-md text-label-md text-primary-fixed-dim mb-md uppercase tracking-wider"
+          >
+            Services
+          </div>
+          <ul class="flex flex-col gap-sm">
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="services.html#it-infrastructure"
+                >IT Infrastructure</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="services.html#powershell-automation"
+                >PowerShell &amp; Automation</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="services.html#cloud-solutions"
+                >Cloud Solutions</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="services.html#data-engineering"
+                >Data Engineering</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="services.html#security-compliance"
+                >Security &amp; Compliance</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="services.html#devsecops"
+                >DevSecOps</a
+              >
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            class="font-label-md text-label-md text-primary-fixed-dim mb-md uppercase tracking-wider"
+          >
+            Quick Links
+          </div>
+          <ul class="flex flex-col gap-sm">
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="team.html"
+                >Meet the Team</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="case-studies.html"
+                >Case Studies</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="testimonials.html"
+                >Testimonials</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-primary-fixed-dim font-bold"
+                href="blog.html"
+                >Blog</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="contact.html"
+                >Contact</a
+              >
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            class="font-label-md text-label-md text-primary-fixed-dim mb-md uppercase tracking-wider"
+          >
+            Connect
+          </div>
+          <ul class="flex flex-col gap-sm">
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors inline-flex items-center gap-xs"
+                href="https://www.linkedin.com/in/lukeleigh"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span class="material-symbols-outlined text-sm">link</span> Luke
+                on LinkedIn
+              </a>
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors inline-flex items-center gap-xs"
+                href="https://www.linkedin.com/in/markleigh"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span class="material-symbols-outlined text-sm">link</span> Mark
+                on LinkedIn
+              </a>
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors inline-flex items-center gap-xs"
+                href="https://github.com/BanterBoy"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span class="material-symbols-outlined text-sm">code</span>
+                GitHub (BanterBoy)
+              </a>
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors inline-flex items-center gap-xs"
+                href="https://blog.lukeleigh.com"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span class="material-symbols-outlined text-sm">rss_feed</span>
+                Luke's Blog
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div
+        class="max-w-7xl mx-auto px-lg py-md border-t border-outline-variant/30"
+      >
+        <p
+          class="font-body-sm text-body-sm text-on-surface-variant text-center"
+        >
+          &copy; 2024&ndash;2026 Leigh IT Services Ltd. All rights reserved.
+        </p>
+      </div>
+    </footer>
+  </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -681,11 +681,12 @@
                 Get monthly technical breakdowns and security alerts delivered
                 to your inbox.
               </p>
-              <form class="space-y-sm" action="#" method="post">
+              <form class="space-y-sm" action="https://formspree.io/xvowjgjd" method="post">
                 <input
                   class="w-full bg-surface-container-lowest border border-outline-variant rounded-lg px-md py-sm text-body-sm focus:border-primary-fixed-dim outline-none"
                   placeholder="email@enterprise.com"
                   type="email"
+                  name="email"
                   aria-label="Email address"
                 />
                 <button

--- a/case-studies.html
+++ b/case-studies.html
@@ -158,6 +158,7 @@
         box-shadow: 0 0 15px #00e5ff;
       }
     </style>
+    <script src="assets/js/metrics.js"></script>
   </head>
   <body
     class="selection:bg-primary-container selection:text-on-primary-container"

--- a/case-studies.html
+++ b/case-studies.html
@@ -163,6 +163,16 @@
   <body
     class="selection:bg-primary-container selection:text-on-primary-container"
   >
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden"
+      ></iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <!-- Top Navigation Bar -->
     <header
       class="bg-surface-container-lowest border-b border-outline-variant sticky top-0 z-50"

--- a/case-studies.html
+++ b/case-studies.html
@@ -1,214 +1,971 @@
-<!DOCTYPE HTML>
-<html lang="en-gb">
-	<head>
-		<title>Case Studies | Leigh Services</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<meta name="description" content="Real-world project delivery by Leigh Services — infrastructure migrations, PCI DSS compliance programmes, data platform engineering and PowerShell automation." />
-		<meta name="keywords" content="IT case studies, PCI DSS, infrastructure migration, data engineering, PowerShell automation, Leigh Services" />
-		<meta property="og:title" content="Case Studies | Leigh Services" />
-		<meta property="og:description" content="Real-world project delivery — infrastructure migrations, PCI compliance, data platform engineering and automation." />
-		<meta property="og:url" content="https://leigh-services.com/case-studies.html" />
-		<meta property="og:image" content="https://leigh-services.com/images/banner.jpg" />
-		<meta property="og:type" content="website" />
-		<meta property="og:site_name" content="Leigh Services" />
-		<meta http-equiv="content-language" content="en-gb" />
-		<link rel="canonical" href="https://leigh-services.com/case-studies.html" />
-		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Case Studies | Leigh Services" />
-		<meta name="twitter:description" content="Real-world project delivery — infrastructure migrations, PCI compliance, data platform engineering and automation." />
-		<meta name="twitter:image" content="https://leigh-services.com/images/banner.jpg" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<style>
-			.case-meta {
-				font-size: 0.78em;
-				font-weight: 700;
-				text-transform: uppercase;
-				letter-spacing: 0.1em;
-				color: #ce1b28;
-				margin-bottom: 0.6em;
-			}
-			.case-outcome {
-				margin-top: 1em;
-				padding: 0.7em 1em;
-				background: #111;
-				color: #fff;
-				border-radius: 4px;
-				font-size: 0.82em;
-				font-weight: 600;
-				letter-spacing: 0.04em;
-			}
-		</style>
-		<script src="assets/js/metrics.js"></script>
-	</head>
-	<body class="is-preload">
-		<!-- Google Tag Manager (noscript) -->
-		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-		<!-- End Google Tag Manager (noscript) -->
+<!doctype html>
+<html class="dark" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Case Studies | Leigh Services</title>
+    <meta
+      name="description"
+      content="Real-world project delivery by Leigh Services — infrastructure migrations, PCI DSS compliance programmes, data platform engineering and PowerShell automation."
+    />
+    <meta
+      name="keywords"
+      content="IT case studies, PCI DSS, infrastructure migration, data engineering, PowerShell automation, Leigh Services"
+    />
+    <link rel="canonical" href="https://leigh-services.com/case-studies.html" />
+    <meta property="og:title" content="Case Studies | Leigh Services" />
+    <meta
+      property="og:description"
+      content="Real-world project delivery — infrastructure migrations, PCI compliance, data platform engineering and automation."
+    />
+    <meta
+      property="og:url"
+      content="https://leigh-services.com/case-studies.html"
+    />
+    <meta
+      property="og:image"
+      content="https://leigh-services.com/images/banner.jpg"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Leigh Services" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Case Studies | Leigh Services" />
+    <meta
+      name="twitter:description"
+      content="Real-world project delivery — infrastructure migrations, PCI compliance, data platform engineering and automation."
+    />
+    <meta
+      name="twitter:image"
+      content="https://leigh-services.com/images/banner.jpg"
+    />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
+      rel="stylesheet"
+    />
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&amp;family=JetBrains+Mono:wght@100..800&amp;display=swap"
+      rel="stylesheet"
+    />
+    <script id="tailwind-config">
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            colors: {
+              "surface-container-low": "#131c2b",
+              "outline-variant": "#3b494c",
+              "on-error": "#690005",
+              "on-tertiary-fixed": "#001945",
+              "surface-container-lowest": "#060e1d",
+              "on-background": "#dbe2f8",
+              "error-container": "#93000a",
+              "on-secondary": "#1b247f",
+              "surface-tint": "#00daf3",
+              "tertiary-container": "#bfd0ff",
+              "primary-container": "#00e5ff",
+              "on-tertiary-fixed-variant": "#00429c",
+              "on-secondary-fixed-variant": "#343d96",
+              "inverse-surface": "#dbe2f8",
+              "inverse-primary": "#006875",
+              "surface-container": "#18202f",
+              surface: "#0b1323",
+              "on-primary-container": "#00626e",
+              "on-primary-fixed": "#001f24",
+              error: "#ffb4ab",
+              "surface-container-high": "#222a3a",
+              "secondary-fixed": "#e0e0ff",
+              "on-secondary-container": "#a8afff",
+              "tertiary-fixed-dim": "#b0c6ff",
+              "secondary-container": "#343d96",
+              "primary-fixed-dim": "#00daf3",
+              tertiary: "#e8ecff",
+              "on-tertiary-container": "#2455af",
+              "on-primary-fixed-variant": "#004f58",
+              "on-secondary-fixed": "#000767",
+              primary: "#c3f5ff",
+              background: "#0b1323",
+              "on-tertiary": "#002d6f",
+              "on-primary": "#00363d",
+              "on-error-container": "#ffdad6",
+              "inverse-on-surface": "#283041",
+              "surface-variant": "#2d3546",
+              "surface-container-highest": "#2d3546",
+              secondary: "#bdc2ff",
+              outline: "#849396",
+              "on-surface-variant": "#bac9cc",
+              "surface-bright": "#31394a",
+              "primary-fixed": "#9cf0ff",
+              "tertiary-fixed": "#d9e2ff",
+              "surface-dim": "#0b1323",
+              "on-surface": "#dbe2f8",
+              "secondary-fixed-dim": "#bdc2ff",
+            },
+            borderRadius: {
+              DEFAULT: "0.125rem",
+              lg: "0.25rem",
+              xl: "0.5rem",
+              full: "0.75rem",
+            },
+            spacing: {
+              xs: "4px",
+              margin: "24px",
+              lg: "24px",
+              xl: "40px",
+              gutter: "16px",
+              base: "4px",
+              sm: "8px",
+              md: "16px",
+            },
+            fontFamily: {
+              "headline-lg": ["Geist"],
+              "title-md": ["Geist"],
+              "label-sm": ["JetBrains Mono"],
+              "label-md": ["JetBrains Mono"],
+              "body-sm": ["Geist"],
+              "body-lg": ["Geist"],
+              "display-lg": ["Geist"],
+            },
+          },
+        },
+      };
+    </script>
+    <style>
+      body {
+        background-color: #0b1323;
+        color: #dbe2f8;
+        font-family: "Geist", sans-serif;
+      }
+      .material-symbols-outlined {
+        font-variation-settings:
+          "FILL" 0,
+          "wght" 400,
+          "GRAD" 0,
+          "opsz" 24;
+      }
+      .glass-panel {
+        background: rgba(13, 71, 161, 0.1);
+        backdrop-filter: blur(10px);
+        border: 1px solid rgba(0, 229, 255, 0.1);
+      }
+      .case-card:hover {
+        border-color: #00e5ff;
+        box-shadow: 0 0 20px rgba(0, 229, 255, 0.1);
+      }
+      .glow-hover:hover {
+        box-shadow: 0 0 15px #00e5ff;
+      }
+    </style>
+  </head>
+  <body
+    class="selection:bg-primary-container selection:text-on-primary-container"
+  >
+    <!-- Top Navigation Bar -->
+    <header
+      class="bg-surface-container-lowest border-b border-outline-variant sticky top-0 z-50"
+    >
+      <nav
+        class="flex justify-between items-center px-lg py-md w-full max-w-7xl mx-auto"
+      >
+        <a
+          class="font-headline-lg text-headline-lg font-bold text-primary-fixed-dim tracking-tight"
+          href="index.html"
+          >Leigh Services</a
+        >
+        <!-- Desktop Nav -->
+        <div class="hidden md:flex items-center gap-lg">
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="index.html"
+            >Home</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="services.html"
+            >Services</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="team.html"
+            >Meet the Team</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="certifications.html"
+            >Certifications</a
+          >
+          <a
+            class="text-primary-fixed-dim font-bold border-b-2 border-primary-fixed-dim pb-1"
+            href="case-studies.html"
+            >Case Studies</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="testimonials.html"
+            >Testimonials</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="blog.html"
+            >Blog</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="contact.html"
+            >Contact</a
+          >
+          <a
+            class="ml-md bg-primary-container text-on-primary-fixed px-md py-sm rounded font-bold hover:opacity-80 transition-all"
+            href="contact.html"
+            >Consultation</a
+          >
+        </div>
+        <!-- Mobile Menu Toggle -->
+        <button
+          class="md:hidden text-primary-fixed-dim"
+          onclick="
+            document.getElementById('mobile-menu').classList.toggle('hidden')
+          "
+        >
+          <span class="material-symbols-outlined">menu</span>
+        </button>
+      </nav>
+    </header>
+    <!-- Mobile Menu -->
+    <div
+      class="hidden md:hidden fixed inset-0 z-[110] bg-surface-container-lowest p-lg"
+      id="mobile-menu"
+    >
+      <div class="flex flex-col gap-md">
+        <div class="flex justify-between items-center mb-xl">
+          <span class="font-headline-lg text-headline-lg text-primary-fixed-dim"
+            >Leigh Services</span
+          >
+          <button
+            onclick="
+              document.getElementById('mobile-menu').classList.add('hidden')
+            "
+          >
+            <span class="material-symbols-outlined">close</span>
+          </button>
+        </div>
+        <a class="text-title-md py-sm" href="index.html">Home</a>
+        <a class="text-title-md py-sm" href="services.html">Services</a>
+        <a class="text-title-md py-sm" href="team.html">Meet the Team</a>
+        <a class="text-title-md py-sm" href="certifications.html"
+          >Certifications</a
+        >
+        <a
+          class="text-title-md py-sm text-primary-fixed-dim font-bold"
+          href="case-studies.html"
+          >Case Studies</a
+        >
+        <a class="text-title-md py-sm" href="testimonials.html">Testimonials</a>
+        <a class="text-title-md py-sm" href="blog.html">Blog</a>
+        <a class="text-title-md py-sm" href="contact.html">Contact</a>
+        <a
+          class="mt-md bg-primary-container text-on-primary-fixed text-center px-md py-md rounded font-bold"
+          href="contact.html"
+          >Consultation</a
+        >
+      </div>
+    </div>
 
-		<!-- Header -->
-			<header id="header">
-				<a class="logo" href="index.html">Leigh Services</a>
-				<nav>
-					<a href="#menu">Menu</a>
-				</nav>
-			</header>
+    <main class="relative">
+      <!-- Hero Section -->
+      <section class="relative h-[400px] flex items-center overflow-hidden">
+        <div class="relative z-10 max-w-7xl mx-auto px-lg w-full">
+          <div class="max-w-2xl">
+            <span class="font-label-md text-primary-fixed-dim mb-sm block"
+              >OPERATIONAL INTEGRITY</span
+            >
+            <h1 class="font-display-lg text-display-lg mb-md leading-tight">
+              Proven Engineering <br />
+              <span class="text-primary-fixed-dim">Case Studies</span>
+            </h1>
+            <p class="font-body-lg text-body-lg text-on-surface-variant">
+              A selection of projects delivered by the Leigh Services team —
+              from large-scale infrastructure migrations to data platform
+              engineering and compliance programmes.
+            </p>
+          </div>
+        </div>
+      </section>
 
-		<!-- Nav -->
-			<nav id="menu">
-				<ul class="links">
-					<li><a href="index.html">Home</a></li>
-					<li><a href="services.html">Services</a></li>
-					<li><a href="team.html">Meet the Team</a></li>
-					<li><a href="certifications.html">Certifications</a></li>
-					<li><a href="case-studies.html">Case Studies</a></li>
-					<li><a href="testimonials.html">Testimonials</a></li>
-					<li><a href="blog.html">Blog</a></li>
-					<li><a href="contact.html">Contact</a></li>
-				</ul>
-			</nav>
+      <!-- Case Studies Grid -->
+      <section class="py-xl max-w-7xl mx-auto px-lg">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-lg">
+          <!-- Project 1: PCI DSS Compliance Programme (Luke) -->
+          <div
+            class="case-card glass-panel p-lg rounded-xl flex flex-col transition-all duration-300 group"
+          >
+            <div class="flex justify-between items-start mb-md">
+              <span
+                class="font-label-sm px-sm py-1 bg-secondary-container text-on-secondary-container rounded"
+                >SECURITY &amp; COMPLIANCE</span
+              >
+              <span class="font-label-sm text-outline">8 Years</span>
+            </div>
+            <h3
+              class="font-headline-lg text-headline-lg mb-sm group-hover:text-primary-fixed-dim transition-colors"
+            >
+              PCI DSS Compliance Programme
+            </h3>
+            <p
+              class="font-label-sm text-outline mb-sm uppercase tracking-widest"
+            >
+              Insurance · 300+ users · Multi-site
+            </p>
+            <p
+              class="font-body-sm text-body-sm text-on-surface-variant mb-lg flex-grow"
+            >
+              Owned and maintained a PCI DSS compliance programme across a
+              four-office WAN infrastructure for eight years. Delivered a full
+              data centre migration to Wales, WAN amalgamation and Mapfre Global
+              WAN integration — while maintaining continuous compliance across
+              the cardholder data environment.
+            </p>
+            <div class="flex flex-wrap gap-xs mb-lg">
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >PCI DSS</span
+              >
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >WAN</span
+              >
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >Data Centre Migration</span
+              >
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >Mapfre</span
+              >
+            </div>
+            <p class="font-body-sm text-body-sm text-primary-fixed-dim mb-md">
+              <span class="font-bold">Outcome:</span> Continuous PCI DSS
+              compliance maintained across an 8-year tenure. Full data centre
+              migration completed with zero compliance gap.
+            </p>
+            <a
+              class="inline-flex items-center gap-xs font-label-md text-primary-fixed-dim uppercase tracking-widest group-hover:gap-sm transition-all"
+              href="services.html#security-compliance"
+            >
+              View Project Scope
+              <span class="material-symbols-outlined text-[18px]"
+                >arrow_forward</span
+              >
+            </a>
+          </div>
 
-		<!-- Heading -->
-			<div id="heading">
-				<h1>Case Studies</h1>
-			</div>
+          <!-- Project 2: SAS to GCP Migration (Mark, Swarovski) -->
+          <div
+            class="case-card glass-panel p-lg rounded-xl flex flex-col transition-all duration-300 group"
+          >
+            <div class="flex justify-between items-start mb-md">
+              <span
+                class="font-label-sm px-sm py-1 bg-primary-container/20 text-primary-fixed-dim rounded"
+                >DATA ENGINEERING</span
+              >
+              <span class="font-label-sm text-outline">9 Months</span>
+            </div>
+            <h3
+              class="font-headline-lg text-headline-lg mb-sm group-hover:text-primary-fixed-dim transition-colors"
+            >
+              SAS to GCP Data Platform Migration
+            </h3>
+            <p
+              class="font-label-sm text-outline mb-sm uppercase tracking-widest"
+            >
+              Luxury Retail (Swarovski) · International · Zurich
+            </p>
+            <p
+              class="font-body-sm text-body-sm text-on-surface-variant mb-lg flex-grow"
+            >
+              Led the migration of a complex, undocumented legacy SAS analytics
+              environment to Google Cloud Platform for a global luxury retailer.
+              Delivered within 9 months, reducing pipeline failure rates from
+              ~25% to 2% and cutting processing time by over 50%.
+            </p>
+            <div class="flex flex-wrap gap-xs mb-lg">
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >SAS</span
+              >
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >GCP</span
+              >
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >Data Pipelines</span
+              >
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >Analytics</span
+              >
+            </div>
+            <p class="font-body-sm text-body-sm text-primary-fixed-dim mb-md">
+              <span class="font-bold">Outcome:</span> €1m in annual cost
+              savings. Failure rate reduced from 25% to 2%. Processing time cut
+              by 50%+.
+            </p>
+            <a
+              class="inline-flex items-center gap-xs font-label-md text-primary-fixed-dim uppercase tracking-widest group-hover:gap-sm transition-all"
+              href="services.html#data-engineering"
+            >
+              View Project Scope
+              <span class="material-symbols-outlined text-[18px]"
+                >arrow_forward</span
+              >
+            </a>
+          </div>
 
-		<!-- Case Studies Grid -->
-			<section class="wrapper">
-				<div class="inner">
-					<header class="special">
-						<h2>Project Delivery</h2>
-						<p>A selection of projects delivered by the Leigh Services team — from large-scale infrastructure migrations to data platform engineering and compliance programmes.</p>
-					</header>
-					<div class="highlights">
+          <!-- Project 3: Ventrica - PowerShell + PCI (Luke) -->
+          <div
+            class="case-card glass-panel p-lg rounded-xl flex flex-col transition-all duration-300 group"
+          >
+            <div class="flex justify-between items-start mb-md">
+              <span
+                class="font-label-sm px-sm py-1 bg-error-container/20 text-error rounded"
+                >AUTOMATION &amp; SECURITY</span
+              >
+              <span class="font-label-sm text-outline">Fixed Deadline</span>
+            </div>
+            <h3
+              class="font-headline-lg text-headline-lg mb-sm group-hover:text-primary-fixed-dim transition-colors"
+            >
+              Infrastructure Automation &amp; PCI Remediation
+            </h3>
+            <p
+              class="font-label-sm text-outline mb-sm uppercase tracking-widest"
+            >
+              Contact Centre (Ventrica) · Fixed Deadline
+            </p>
+            <p
+              class="font-body-sm text-body-sm text-on-surface-variant mb-lg flex-grow"
+            >
+              Engaged to deliver a full PCI DSS compliance programme within a
+              non-negotiable year-end deadline. Delivered Juniper firewall
+              upgrades, patch management, Active Directory hardening and
+              Exchange Server 2013 security hardening — with PowerShell
+              automation driving consistency across the remediation effort.
+            </p>
+            <div class="flex flex-wrap gap-xs mb-lg">
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >PowerShell</span
+              >
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >PCI DSS</span
+              >
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >Juniper</span
+              >
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >Exchange 2013</span
+              >
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >Active Directory</span
+              >
+            </div>
+            <p class="font-body-sm text-body-sm text-primary-fixed-dim mb-md">
+              <span class="font-bold">Outcome:</span> PCI DSS compliance
+              achieved by December 31st deadline. All remediation items closed.
+            </p>
+            <a
+              class="inline-flex items-center gap-xs font-label-md text-primary-fixed-dim uppercase tracking-widest group-hover:gap-sm transition-all"
+              href="services.html#powershell-automation"
+            >
+              View Project Scope
+              <span class="material-symbols-outlined text-[18px]"
+                >arrow_forward</span
+              >
+            </a>
+          </div>
 
-						<section>
-							<div class="content">
-								<header>
-									<a href="services.html#security-compliance" class="icon fa-shield"><span class="label">PCI DSS Compliance</span></a>
-									<h3>PCI DSS Compliance Programme</h3>
-								</header>
-								<p class="case-meta">Insurance &middot; 300+ users &middot; Multi-site</p>
-								<p>Owned and maintained a PCI DSS compliance programme across a four-office WAN infrastructure for eight years. Delivered a full data centre migration to Wales, WAN amalgamation and Mapfre Global WAN integration — while maintaining continuous compliance across the cardholder data environment.</p>
-								<p class="case-outcome">Outcome: Continuous PCI DSS compliance maintained across an 8-year tenure. Full data centre migration completed with zero compliance gap.</p>
-							</div>
-						</section>
+          <!-- Project 4: Carpetright - M365 + VMware (Luke) -->
+          <div
+            class="case-card glass-panel p-lg rounded-xl flex flex-col transition-all duration-300 group"
+          >
+            <div class="flex justify-between items-start mb-md">
+              <span
+                class="font-label-sm px-sm py-1 bg-tertiary-container/20 text-on-tertiary-container rounded"
+                >INFRASTRUCTURE</span
+              >
+              <span class="font-label-sm text-outline">UK-wide</span>
+            </div>
+            <h3
+              class="font-headline-lg text-headline-lg mb-sm group-hover:text-primary-fixed-dim transition-colors"
+            >
+              Microsoft 365 Migration &amp; Virtualisation
+            </h3>
+            <p
+              class="font-label-sm text-outline mb-sm uppercase tracking-widest"
+            >
+              Retail (Carpetright) · 200+ stores · UK-wide
+            </p>
+            <p
+              class="font-body-sm text-body-sm text-on-surface-variant mb-lg flex-grow"
+            >
+              Delivered a Microsoft 365 migration and VMware virtualisation
+              programme for a UK-wide retail group, covering messaging
+              platforms, change management and ongoing IT infrastructure
+              support. Managed transition during an organisationally complex
+              period.
+            </p>
+            <div class="flex flex-wrap gap-xs mb-lg">
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >Microsoft 365</span
+              >
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >VMware</span
+              >
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >Migration</span
+              >
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >Change Management</span
+              >
+            </div>
+            <p class="font-body-sm text-body-sm text-primary-fixed-dim mb-md">
+              <span class="font-bold">Outcome:</span> Successful M365 migration
+              delivered. Virtualisation estate stabilised and handed over.
+            </p>
+            <a
+              class="inline-flex items-center gap-xs font-label-md text-primary-fixed-dim uppercase tracking-widest group-hover:gap-sm transition-all"
+              href="services.html#it-infrastructure"
+            >
+              View Project Scope
+              <span class="material-symbols-outlined text-[18px]"
+                >arrow_forward</span
+              >
+            </a>
+          </div>
 
-						<section>
-							<div class="content">
-								<header>
-									<a href="services.html#data-engineering" class="icon fa-database"><span class="label">Data Platform Migration</span></a>
-									<h3>SAS to GCP Data Platform Migration</h3>
-								</header>
-								<p class="case-meta">Luxury Retail &middot; International &middot; Zurich</p>
-								<p>Led the migration of a complex, undocumented legacy SAS analytics environment to Google Cloud Platform for a global luxury retailer. Delivered within 9 months, reducing pipeline failure rates from ~25% to 2% and cutting processing time by over 50%.</p>
-								<p class="case-outcome">Outcome: &euro;1m in annual cost savings. Failure rate reduced from 25% to 2%. Processing time cut by 50%+.</p>
-							</div>
-						</section>
+          <!-- Project 5: Lloyds FINREP (Mark) -->
+          <div
+            class="case-card glass-panel p-lg rounded-xl flex flex-col transition-all duration-300 group"
+          >
+            <div class="flex justify-between items-start mb-md">
+              <span
+                class="font-label-sm px-sm py-1 bg-secondary-container text-on-secondary-container rounded"
+                >REGULATORY REPORTING</span
+              >
+              <span class="font-label-sm text-outline">Halifax</span>
+            </div>
+            <h3
+              class="font-headline-lg text-headline-lg mb-sm group-hover:text-primary-fixed-dim transition-colors"
+            >
+              FINREP Regulatory Reporting Programme
+            </h3>
+            <p
+              class="font-label-sm text-outline mb-sm uppercase tracking-widest"
+            >
+              Banking (Lloyds) · Regulatory · Halifax
+            </p>
+            <p
+              class="font-body-sm text-body-sm text-on-surface-variant mb-lg flex-grow"
+            >
+              Lead developer on a FINREP (Financial Reporting) regulatory
+              programme within a major UK bank — bridging project management and
+              development to deliver a complex regulatory data solution. Also
+              contributed to a Collections &amp; Recoveries migration applying
+              Agile principles within a Waterfall-governed environment.
+            </p>
+            <div class="flex flex-wrap gap-xs mb-lg">
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >FINREP</span
+              >
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >Regulatory</span
+              >
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >SAS</span
+              >
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >Agile</span
+              >
+            </div>
+            <p class="font-body-sm text-body-sm text-primary-fixed-dim mb-md">
+              <span class="font-bold">Outcome:</span> FINREP solution delivered
+              to regulatory deadline. Agile delivery model introduced within a
+              traditional Waterfall programme.
+            </p>
+            <a
+              class="inline-flex items-center gap-xs font-label-md text-primary-fixed-dim uppercase tracking-widest group-hover:gap-sm transition-all"
+              href="services.html#data-engineering"
+            >
+              View Project Scope
+              <span class="material-symbols-outlined text-[18px]"
+                >arrow_forward</span
+              >
+            </a>
+          </div>
 
-						<section>
-							<div class="content">
-								<header>
-									<a href="services.html#powershell-automation" class="icon fa-cogs"><span class="label">PowerShell Automation</span></a>
-									<h3>Infrastructure Automation &amp; PCI Remediation</h3>
-								</header>
-								<p class="case-meta">Contact Centre &middot; Fixed Deadline</p>
-								<p>Engaged to deliver a full PCI DSS compliance programme within a non-negotiable year-end deadline. Delivered Juniper firewall upgrades, patch management, Active Directory hardening and Exchange Server 2013 security hardening — with PowerShell automation driving consistency across the remediation effort.</p>
-								<p class="case-outcome">Outcome: PCI DSS compliance achieved by December 31st deadline. All remediation items closed.</p>
-							</div>
-						</section>
+          <!-- Project 6: Solopress - VMware + Exchange (Luke) -->
+          <div
+            class="case-card glass-panel p-lg rounded-xl flex flex-col transition-all duration-300 group"
+          >
+            <div class="flex justify-between items-start mb-md">
+              <span
+                class="font-label-sm px-sm py-1 bg-primary-container/20 text-primary-fixed-dim rounded"
+                >CLOUD &amp; VIRTUALISATION</span
+              >
+              <span class="font-label-sm text-outline">Southend-on-Sea</span>
+            </div>
+            <h3
+              class="font-headline-lg text-headline-lg mb-sm group-hover:text-primary-fixed-dim transition-colors"
+            >
+              VMware &amp; Exchange Cloud Migration
+            </h3>
+            <p
+              class="font-label-sm text-outline mb-sm uppercase tracking-widest"
+            >
+              Print Industry (Solopress) · Southend-on-Sea
+            </p>
+            <p
+              class="font-body-sm text-body-sm text-on-surface-variant mb-lg flex-grow"
+            >
+              Implemented a Dell EMC and VMware 6.5 virtual environment from
+              scratch, migrated from GFI Kerio Connect to Exchange 365, and
+              integrated with Azure Active Directory — delivering a modern,
+              cloud-connected infrastructure for a growing print business.
+            </p>
+            <div class="flex flex-wrap gap-xs mb-lg">
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >Dell EMC</span
+              >
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >VMware 6.5</span
+              >
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >Exchange 365</span
+              >
+              <span
+                class="font-label-sm bg-surface-container-high px-2 py-1 rounded"
+                >Azure AD</span
+              >
+            </div>
+            <p class="font-body-sm text-body-sm text-primary-fixed-dim mb-md">
+              <span class="font-bold">Outcome:</span> Full virtualisation
+              completed. Exchange 365 live with Azure AD integration.
+              Infrastructure modernised within a single engagement.
+            </p>
+            <a
+              class="inline-flex items-center gap-xs font-label-md text-primary-fixed-dim uppercase tracking-widest group-hover:gap-sm transition-all"
+              href="services.html#cloud-solutions"
+            >
+              View Project Scope
+              <span class="material-symbols-outlined text-[18px]"
+                >arrow_forward</span
+              >
+            </a>
+          </div>
+        </div>
+      </section>
 
-						<section>
-							<div class="content">
-								<header>
-									<a href="services.html#it-infrastructure" class="icon fa-server"><span class="label">Infrastructure Migration</span></a>
-									<h3>Microsoft 365 Migration &amp; Virtualisation</h3>
-								</header>
-								<p class="case-meta">Retail &middot; 200+ stores &middot; UK-wide</p>
-								<p>Delivered a Microsoft 365 migration and VMware virtualisation programme for a UK-wide retail group, covering messaging platforms, change management and ongoing IT infrastructure support. Managed transition during an organisationally complex period.</p>
-								<p class="case-outcome">Outcome: Successful M365 migration delivered. Virtualisation estate stabilised and handed over.</p>
-							</div>
-						</section>
+      <!-- Operational Excellence Metrics -->
+      <section class="py-xl bg-surface-container-low">
+        <div class="max-w-7xl mx-auto px-lg">
+          <h2
+            class="font-headline-lg text-headline-lg mb-xl border-l-4 border-primary-fixed-dim pl-md"
+          >
+            Operational Excellence Metrics
+          </h2>
+          <div class="grid grid-cols-1 md:grid-cols-4 gap-md">
+            <div
+              class="p-lg bg-surface-container-high rounded-xl border border-outline-variant flex flex-col justify-center text-center"
+            >
+              <div class="text-display-lg font-bold text-primary-fixed-dim">
+                €1M+
+              </div>
+              <div class="font-label-md uppercase text-outline">
+                Annual Cost Savings
+              </div>
+              <div class="mt-sm font-body-sm text-on-surface-variant">
+                SAS-to-GCP Migration (Swarovski)
+              </div>
+            </div>
+            <div
+              class="p-lg bg-surface-container-high rounded-xl border border-outline-variant flex flex-col justify-center text-center"
+            >
+              <div class="text-display-lg font-bold text-primary-fixed-dim">
+                8 Yrs
+              </div>
+              <div class="font-label-md uppercase text-outline">
+                Continuous Compliance
+              </div>
+              <div class="mt-sm font-body-sm text-on-surface-variant">
+                PCI DSS Programme Tenure
+              </div>
+            </div>
+            <div
+              class="p-lg bg-surface-container-high rounded-xl border border-outline-variant flex flex-col justify-center text-center"
+            >
+              <div class="text-display-lg font-bold text-primary-fixed-dim">
+                6
+              </div>
+              <div class="font-label-md uppercase text-outline">
+                Projects Delivered
+              </div>
+              <div class="mt-sm font-body-sm text-on-surface-variant">
+                Across Retail, Banking &amp; Insurance
+              </div>
+            </div>
+            <div
+              class="p-lg bg-surface-container-high rounded-xl border border-outline-variant flex flex-col justify-center text-center"
+            >
+              <div class="text-display-lg font-bold text-primary-fixed-dim">
+                50%+
+              </div>
+              <div class="font-label-md uppercase text-outline">
+                Processing Time Cut
+              </div>
+              <div class="mt-sm font-body-sm text-on-surface-variant">
+                Failure rate 25% → 2%
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
 
-						<section>
-							<div class="content">
-								<header>
-									<a href="services.html#data-engineering" class="icon fa-line-chart"><span class="label">Regulatory Reporting</span></a>
-									<h3>FINREP Regulatory Reporting Programme</h3>
-								</header>
-								<p class="case-meta">Banking &middot; Regulatory &middot; Halifax</p>
-								<p>Lead developer on a FINREP (Financial Reporting) regulatory programme within a major UK bank — bridging project management and development to deliver a complex regulatory data solution. Also contributed to a Collections &amp; Recoveries migration applying Agile principles within a Waterfall-governed environment.</p>
-								<p class="case-outcome">Outcome: FINREP solution delivered to regulatory deadline. Agile delivery model introduced within a traditional Waterfall programme.</p>
-							</div>
-						</section>
+      <!-- CTA Section -->
+      <section class="py-xl max-w-7xl mx-auto px-lg text-center">
+        <div class="glass-panel p-xl rounded-2xl relative overflow-hidden">
+          <h2 class="font-display-lg text-display-lg mb-md">
+            Have a similar challenge?
+          </h2>
+          <p
+            class="font-body-lg text-body-lg text-on-surface-variant max-w-2xl mx-auto mb-lg"
+          >
+            Whether you are facing a compliance deadline, a platform migration
+            or a data integrity problem, we have likely seen it before. Get in
+            touch and let's talk through what is possible.
+          </p>
+          <div class="flex flex-col sm:flex-row justify-center gap-md">
+            <a
+              class="bg-primary-container text-on-primary-container px-xl py-md font-bold rounded-full glow-hover transition-all"
+              href="contact.html"
+              >Start Your Consultation</a
+            >
+            <a
+              class="border border-primary-fixed-dim text-primary-fixed-dim px-xl py-md font-bold rounded-full hover:bg-primary-fixed-dim/10 transition-all"
+              href="team.html"
+              >Meet the Team</a
+            >
+          </div>
+        </div>
+      </section>
+    </main>
 
-						<section>
-							<div class="content">
-								<header>
-									<a href="services.html#cloud-solutions" class="icon fa-cloud"><span class="label">Cloud &amp; Virtualisation</span></a>
-									<h3>VMware &amp; Exchange Cloud Migration</h3>
-								</header>
-								<p class="case-meta">Print Industry &middot; Southend-on-Sea</p>
-								<p>Implemented a Dell EMC and VMware 6.5 virtual environment from scratch, migrated from GFI Kerio Connect to Exchange 365, and integrated with Azure Active Directory — delivering a modern, cloud-connected infrastructure for a growing print business.</p>
-								<p class="case-outcome">Outcome: Full virtualisation completed. Exchange 365 live with Azure AD integration. Infrastructure modernised within a single engagement.</p>
-							</div>
-						</section>
+    <!-- Footer -->
+    <footer class="bg-surface-container-lowest border-t border-outline-variant">
+      <div
+        class="grid grid-cols-1 md:grid-cols-4 gap-xl px-lg py-xl max-w-7xl mx-auto"
+      >
+        <div>
+          <div
+            class="font-title-md text-title-md font-bold text-primary-fixed-dim mb-md"
+          >
+            Leigh Services
+          </div>
+          <p class="font-body-sm text-body-sm text-on-surface-variant">
+            Expert IT Infrastructure, Automation and Data Engineering consulting
+            based in Southend-on-Sea, Essex. Serving clients across the UK and
+            internationally.
+          </p>
+          <div class="mt-md font-body-sm text-on-surface-variant">
+            63 Archer Avenue,<br />
+            Southend on Sea, Essex SS2 4QU
+          </div>
+        </div>
+        <div>
+          <h4
+            class="font-label-md text-primary-fixed-dim mb-md uppercase tracking-wider"
+          >
+            Services
+          </h4>
+          <ul class="space-y-sm font-body-sm text-on-surface-variant">
+            <li>
+              <a
+                class="hover:text-primary transition-colors"
+                href="services.html#it-infrastructure"
+                >IT Infrastructure</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary transition-colors"
+                href="services.html#powershell-automation"
+                >PowerShell &amp; Automation</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary transition-colors"
+                href="services.html#cloud-solutions"
+                >Cloud Solutions</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary transition-colors"
+                href="services.html#data-engineering"
+                >Data Engineering</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary transition-colors"
+                href="services.html#security-compliance"
+                >Security &amp; Compliance</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary transition-colors"
+                href="services.html#devsecops"
+                >DevSecOps</a
+              >
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h4
+            class="font-label-md text-primary-fixed-dim mb-md uppercase tracking-wider"
+          >
+            Connect
+          </h4>
+          <ul class="space-y-sm font-body-sm text-on-surface-variant">
+            <li class="flex items-center gap-xs">
+              <span class="material-symbols-outlined text-[18px]">link</span>
+              <a
+                class="hover:text-primary transition-colors"
+                href="https://www.linkedin.com/in/lukeleigh"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Luke on LinkedIn</a
+              >
+            </li>
+            <li class="flex items-center gap-xs">
+              <span class="material-symbols-outlined text-[18px]">link</span>
+              <a
+                class="hover:text-primary transition-colors"
+                href="https://www.linkedin.com/in/markleigh"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Mark on LinkedIn</a
+              >
+            </li>
+            <li class="flex items-center gap-xs">
+              <span class="material-symbols-outlined text-[18px]"
+                >terminal</span
+              >
+              <a
+                class="hover:text-primary transition-colors"
+                href="https://github.com/BanterBoy"
+                target="_blank"
+                rel="noopener noreferrer"
+                >GitHub (BanterBoy)</a
+              >
+            </li>
+            <li class="flex items-center gap-xs">
+              <span class="material-symbols-outlined text-[18px]"
+                >rss_feed</span
+              >
+              <a
+                class="hover:text-primary transition-colors"
+                href="https://blog.lukeleigh.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Luke's Blog</a
+              >
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h4
+            class="font-label-md text-primary-fixed-dim mb-md uppercase tracking-wider"
+          >
+            Navigation
+          </h4>
+          <ul class="space-y-sm font-body-sm text-on-surface-variant">
+            <li>
+              <a class="hover:text-primary transition-colors" href="index.html"
+                >Home</a
+              >
+            </li>
+            <li>
+              <a
+                class="text-primary-fixed-dim font-bold"
+                href="case-studies.html"
+                >Case Studies</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary transition-colors"
+                href="testimonials.html"
+                >Testimonials</a
+              >
+            </li>
+            <li>
+              <a class="hover:text-primary transition-colors" href="blog.html"
+                >Blog</a
+              >
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div
+        class="px-lg py-md border-t border-outline-variant/30 text-center font-body-sm text-body-sm text-on-surface-variant/60"
+      >
+        &copy; 2024&ndash;2026 Leigh IT Services Ltd. All rights reserved.
+      </div>
+    </footer>
 
-					</div>
-				</div>
-			</section>
-
-		<!-- CTA -->
-			<section id="cta" class="wrapper">
-				<div class="inner">
-					<h2>Have a similar challenge?</h2>
-					<p>Whether you are facing a compliance deadline, a platform migration or a data integrity problem, we have likely seen it before. Get in touch and let's talk through what is possible.</p>
-					<a href="contact.html" class="button fit small">Get in Touch</a>
-				</div>
-			</section>
-
-		<!-- Footer -->
-			<footer id="footer">
-				<div class="inner">
-					<div class="content">
-						<section>
-							<h3>Leigh Services</h3>
-							<p>Expert IT Infrastructure, Automation and Data Engineering consulting based in Southend-on-Sea, Essex. Serving clients across the UK and internationally.</p>
-							<p>63 Archer Avenue, Southend on Sea, Essex SS2 4QU</p>
-						</section>
-						<section>
-							<h4>Services</h4>
-							<ul class="alt">
-								<li><a href="services.html#it-infrastructure">IT Infrastructure</a></li>
-								<li><a href="services.html#powershell-automation">PowerShell &amp; Automation</a></li>
-								<li><a href="services.html#cloud-solutions">Cloud Solutions</a></li>
-								<li><a href="services.html#data-engineering">Data Engineering</a></li>
-								<li><a href="services.html#security-compliance">Security &amp; Compliance</a></li>
-								<li><a href="services.html#devsecops">DevSecOps</a></li>
-							</ul>
-						</section>
-						<section>
-							<h4>Connect</h4>
-							<ul class="plain">
-								<li><a href="https://www.linkedin.com/in/lukeleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>Luke on LinkedIn</a></li>
-								<li><a href="https://www.linkedin.com/in/markleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>Mark on LinkedIn</a></li>
-								<li><a href="https://github.com/BanterBoy" target="_blank" rel="noopener noreferrer"><i class="icon fa-github">&nbsp;</i>GitHub (BanterBoy)</a></li>
-								<li><a href="https://blog.lukeleigh.com" target="_blank" rel="noopener noreferrer"><i class="icon fa-rss">&nbsp;</i>Luke's Blog</a></li>
-							</ul>
-						</section>
-					</div>
-					<div class="copyright">
-						&copy; 2024&ndash;2026 Leigh IT Services Ltd. All rights reserved.
-					</div>
-				</div>
-			</footer>
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
-
-	</body>
+    <script>
+      // Smooth reveal for case cards
+      const cards = document.querySelectorAll(".case-card");
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              entry.target.classList.add("opacity-100", "translate-y-0");
+              entry.target.classList.remove("opacity-0", "translate-y-8");
+            }
+          });
+        },
+        { threshold: 0.1 },
+      );
+      cards.forEach((card) => {
+        card.classList.add(
+          "opacity-0",
+          "translate-y-8",
+          "transition-all",
+          "duration-500",
+        );
+        observer.observe(card);
+      });
+    </script>
+  </body>
 </html>

--- a/certifications.html
+++ b/certifications.html
@@ -1,219 +1,948 @@
-<!DOCTYPE HTML>
-<html lang="en-gb">
-	<head>
-		<title>Certifications &amp; Partners | Leigh Services</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<meta name="description" content="Certifications, accreditations and technology partnerships held by the Leigh Services team — CompTIA Security+, CREST CPSA, Microsoft, GCP and more." />
-		<meta name="keywords" content="CompTIA Security+, CREST CPSA, Microsoft 365, GCP, PowerShell Gallery, certifications, Leigh Services" />
-		<meta property="og:title" content="Certifications &amp; Partners | Leigh Services" />
-		<meta property="og:description" content="Certifications and technology partnerships held by the Leigh Services team." />
-		<meta property="og:url" content="https://leigh-services.com/certifications.html" />
-		<meta property="og:image" content="https://leigh-services.com/images/banner.jpg" />
-		<meta property="og:type" content="website" />
-		<meta property="og:site_name" content="Leigh Services" />
-		<meta http-equiv="content-language" content="en-gb" />
-		<link rel="canonical" href="https://leigh-services.com/certifications.html" />
-		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Certifications &amp; Partners | Leigh Services" />
-		<meta name="twitter:description" content="Certifications and technology partnerships held by the Leigh Services team." />
-		<meta name="twitter:image" content="https://leigh-services.com/images/banner.jpg" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<style>
-			.cert-holder {
-				font-size: 0.78em;
-				font-weight: 700;
-				text-transform: uppercase;
-				letter-spacing: 0.1em;
-				color: #ce1b28;
-				margin-top: 0.4em;
-			}
-			.cert-body {
-				font-size: 0.82em;
-				color: #888;
-				margin-top: 0.2em;
-			}
-		</style>
-		<script src="assets/js/metrics.js"></script>
-	</head>
-	<body class="is-preload">
-		<!-- Google Tag Manager (noscript) -->
-		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-		<!-- End Google Tag Manager (noscript) -->
+<!doctype html>
+<html class="dark" lang="en-gb">
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Certifications &amp; Partners | Leigh Services</title>
+    <meta
+      name="description"
+      content="Certifications, accreditations and technology partnerships held by the Leigh Services team — CompTIA Security+, CREST CPSA, Microsoft, GCP and more."
+    />
+    <meta
+      name="keywords"
+      content="CompTIA Security+, CREST CPSA, Microsoft 365, GCP, PowerShell Gallery, certifications, Leigh Services"
+    />
+    <meta
+      property="og:title"
+      content="Certifications &amp; Partners | Leigh Services"
+    />
+    <meta
+      property="og:description"
+      content="Certifications and technology partnerships held by the Leigh Services team."
+    />
+    <meta
+      property="og:url"
+      content="https://leigh-services.com/certifications.html"
+    />
+    <meta
+      property="og:image"
+      content="https://leigh-services.com/images/banner.jpg"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Leigh Services" />
+    <meta http-equiv="content-language" content="en-gb" />
+    <link
+      rel="canonical"
+      href="https://leigh-services.com/certifications.html"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="Certifications &amp; Partners | Leigh Services"
+    />
+    <meta
+      name="twitter:description"
+      content="Certifications and technology partnerships held by the Leigh Services team."
+    />
+    <meta
+      name="twitter:image"
+      content="https://leigh-services.com/images/banner.jpg"
+    />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&amp;family=JetBrains+Mono:wght@100..800&amp;display=swap"
+      rel="stylesheet"
+    />
+    <script src="assets/js/metrics.js"></script>
+    <script id="tailwind-config">
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            colors: {
+              "surface-container-low": "#131c2b",
+              "outline-variant": "#3b494c",
+              "on-error": "#690005",
+              "on-tertiary-fixed": "#001945",
+              "surface-container-lowest": "#060e1d",
+              "on-background": "#dbe2f8",
+              "error-container": "#93000a",
+              "on-secondary": "#1b247f",
+              "surface-tint": "#00daf3",
+              "tertiary-container": "#bfd0ff",
+              "primary-container": "#00e5ff",
+              "on-tertiary-fixed-variant": "#00429c",
+              "on-secondary-fixed-variant": "#343d96",
+              "inverse-surface": "#dbe2f8",
+              "inverse-primary": "#006875",
+              "surface-container": "#18202f",
+              surface: "#0b1323",
+              "on-primary-container": "#00626e",
+              "on-primary-fixed": "#001f24",
+              error: "#ffb4ab",
+              "surface-container-high": "#222a3a",
+              "secondary-fixed": "#e0e0ff",
+              "on-secondary-container": "#a8afff",
+              "tertiary-fixed-dim": "#b0c6ff",
+              "secondary-container": "#343d96",
+              "primary-fixed-dim": "#00daf3",
+              tertiary: "#e8ecff",
+              "on-tertiary-container": "#2455af",
+              "on-primary-fixed-variant": "#004f58",
+              "on-secondary-fixed": "#000767",
+              primary: "#c3f5ff",
+              background: "#0b1323",
+              "on-tertiary": "#002d6f",
+              "on-primary": "#00363d",
+              "on-error-container": "#ffdad6",
+              "inverse-on-surface": "#283041",
+              "surface-variant": "#2d3546",
+              "surface-container-highest": "#2d3546",
+              secondary: "#bdc2ff",
+              outline: "#849396",
+              "on-surface-variant": "#bac9cc",
+              "surface-bright": "#31394a",
+              "primary-fixed": "#9cf0ff",
+              "tertiary-fixed": "#d9e2ff",
+              "surface-dim": "#0b1323",
+              "on-surface": "#dbe2f8",
+              "secondary-fixed-dim": "#bdc2ff",
+            },
+            borderRadius: {
+              DEFAULT: "0.125rem",
+              lg: "0.25rem",
+              xl: "0.5rem",
+              full: "0.75rem",
+            },
+            spacing: {
+              xs: "4px",
+              margin: "24px",
+              lg: "24px",
+              xl: "40px",
+              gutter: "16px",
+              base: "4px",
+              sm: "8px",
+              md: "16px",
+            },
+            fontFamily: {
+              "headline-lg": ["Geist"],
+              "title-md": ["Geist"],
+              "label-sm": ["JetBrains Mono"],
+              "body-sm": ["Geist"],
+              "label-md": ["JetBrains Mono"],
+              "body-lg": ["Geist"],
+              "display-lg": ["Geist"],
+            },
+            fontSize: {
+              "headline-lg": [
+                "32px",
+                { lineHeight: "40px", fontWeight: "600" },
+              ],
+              "title-md": ["20px", { lineHeight: "28px", fontWeight: "500" }],
+              "label-sm": [
+                "10px",
+                {
+                  lineHeight: "14px",
+                  letterSpacing: "0.05em",
+                  fontWeight: "500",
+                },
+              ],
+              "body-sm": ["14px", { lineHeight: "20px", fontWeight: "400" }],
+              "label-md": [
+                "12px",
+                {
+                  lineHeight: "16px",
+                  letterSpacing: "0.05em",
+                  fontWeight: "500",
+                },
+              ],
+              "body-lg": ["16px", { lineHeight: "24px", fontWeight: "400" }],
+              "display-lg": [
+                "48px",
+                {
+                  lineHeight: "56px",
+                  letterSpacing: "-0.02em",
+                  fontWeight: "700",
+                },
+              ],
+            },
+          },
+        },
+      };
+    </script>
+    <style>
+      body {
+        background-color: #0b1323;
+        color: #dbe2f8;
+        font-family: "Geist", sans-serif;
+        margin: 0;
+      }
+      .certification-card {
+        background: rgba(13, 71, 161, 0.1);
+        border: 1px solid rgba(0, 229, 255, 0.1);
+        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+      }
+      .certification-card:hover {
+        border-color: #00e5ff;
+        background: rgba(13, 71, 161, 0.2);
+        transform: translateY(-2px);
+        box-shadow: 0 0 20px rgba(0, 229, 255, 0.1);
+      }
+      .glow-button:hover {
+        box-shadow: 0 0 15px rgba(0, 229, 255, 0.4);
+      }
+      .material-symbols-outlined {
+        font-variation-settings:
+          "FILL" 0,
+          "wght" 400,
+          "GRAD" 0,
+          "opsz" 24;
+      }
+    </style>
+  </head>
+  <body
+    class="min-h-screen flex flex-col selection:bg-primary-container selection:text-on-primary-container"
+  >
+    <!-- Google Tag Manager (noscript) -->
+    <noscript
+      ><iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden"
+      ></iframe
+    ></noscript>
 
-		<!-- Header -->
-			<header id="header">
-				<a class="logo" href="index.html">Leigh Services</a>
-				<nav>
-					<a href="#menu">Menu</a>
-				</nav>
-			</header>
+    <!-- Header / Top Nav -->
+    <header
+      class="fixed top-0 left-0 w-full z-50 bg-surface-container-lowest border-b border-outline-variant"
+    >
+      <div
+        class="flex justify-between items-center px-lg py-md w-full max-w-7xl mx-auto h-20"
+      >
+        <a
+          class="font-headline-lg text-headline-lg font-bold text-primary-fixed-dim tracking-tight"
+          href="index.html"
+          >Leigh Services</a
+        >
+        <nav class="hidden md:flex items-center space-x-lg">
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="index.html"
+            >Home</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="services.html"
+            >Services</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="team.html"
+            >Meet the Team</a
+          >
+          <a
+            class="text-primary-fixed-dim font-bold border-b-2 border-primary-fixed-dim pb-1"
+            href="certifications.html"
+            >Certifications</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="case-studies.html"
+            >Case Studies</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="testimonials.html"
+            >Testimonials</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="blog.html"
+            >Blog</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="contact.html"
+            >Contact</a
+          >
+        </nav>
+        <div class="flex items-center gap-md">
+          <a
+            class="hidden md:inline-block bg-primary-container text-on-primary-container px-md py-sm rounded font-bold glow-button transition-all"
+            href="contact.html"
+            >Consultation</a
+          >
+          <button
+            class="md:hidden text-primary-fixed-dim"
+            onclick="
+              document.getElementById('mobile-menu').classList.toggle('hidden')
+            "
+          >
+            <span class="material-symbols-outlined">menu</span>
+          </button>
+        </div>
+      </div>
+    </header>
 
-		<!-- Nav -->
-			<nav id="menu">
-				<ul class="links">
-					<li><a href="index.html">Home</a></li>
-					<li><a href="services.html">Services</a></li>
-					<li><a href="team.html">Meet the Team</a></li>
-					<li><a href="certifications.html">Certifications</a></li>
-					<li><a href="case-studies.html">Case Studies</a></li>
-					<li><a href="testimonials.html">Testimonials</a></li>
-					<li><a href="blog.html">Blog</a></li>
-					<li><a href="contact.html">Contact</a></li>
-				</ul>
-			</nav>
+    <!-- Mobile Menu -->
+    <div
+      class="hidden md:hidden fixed inset-0 z-[110] bg-surface-container-lowest p-lg"
+      id="mobile-menu"
+    >
+      <div class="flex flex-col gap-md">
+        <div class="flex justify-between items-center mb-xl">
+          <span class="font-headline-lg text-headline-lg text-primary-fixed-dim"
+            >Leigh Services</span
+          >
+          <button
+            onclick="
+              document.getElementById('mobile-menu').classList.add('hidden')
+            "
+          >
+            <span class="material-symbols-outlined">close</span>
+          </button>
+        </div>
+        <a class="text-title-md py-sm" href="index.html">Home</a>
+        <a class="text-title-md py-sm" href="services.html">Services</a>
+        <a class="text-title-md py-sm" href="team.html">Meet the Team</a>
+        <a
+          class="text-title-md py-sm text-primary-fixed-dim font-bold"
+          href="certifications.html"
+          >Certifications</a
+        >
+        <a class="text-title-md py-sm" href="case-studies.html">Case Studies</a>
+        <a class="text-title-md py-sm" href="testimonials.html">Testimonials</a>
+        <a class="text-title-md py-sm" href="blog.html">Blog</a>
+        <a class="text-title-md py-sm" href="contact.html">Contact</a>
+        <a
+          class="mt-md bg-primary-container text-on-primary-container text-center px-md py-md rounded font-bold"
+          href="contact.html"
+          >Consultation</a
+        >
+      </div>
+    </div>
 
-		<!-- Heading -->
-			<div id="heading">
-				<h1>Certifications &amp; Partners</h1>
-			</div>
+    <main class="flex-grow pt-32 pb-xl px-lg max-w-7xl mx-auto w-full">
+      <!-- Hero Section -->
+      <section
+        class="mb-xl relative overflow-hidden rounded-xl bg-surface-container-low p-xl border border-outline-variant"
+      >
+        <div class="relative z-10 max-w-2xl">
+          <div
+            class="inline-flex items-center gap-xs px-sm py-xs bg-secondary-container text-on-secondary-container rounded mb-md"
+          >
+            <span class="material-symbols-outlined text-[16px]">verified</span>
+            <span class="font-label-md text-label-md uppercase tracking-wider"
+              >Accredited Expertise</span
+            >
+          </div>
+          <h1 class="font-display-lg text-display-lg text-on-background mb-md">
+            Certifications &amp; Partners
+          </h1>
+          <p
+            class="font-body-lg text-body-lg text-on-surface-variant leading-relaxed"
+          >
+            Formal certifications, accreditations and technology partnerships
+            held by the Leigh Services team. We maintain rigorous,
+            industry-standard credentials across security, cloud platforms and
+            data engineering to back every engagement with verified expertise.
+          </p>
+        </div>
+      </section>
 
-		<!-- Certifications -->
-			<section class="wrapper">
-				<div class="inner">
-					<header class="special">
-						<h2>Professional Certifications</h2>
-						<p>Formal certifications and accreditations held by the Leigh Services team.</p>
-					</header>
-					<div class="highlights">
+      <!-- Professional Certifications: Bento Grid -->
+      <header class="mb-lg">
+        <h2 class="font-headline-lg text-headline-lg text-on-background">
+          Professional Certifications
+        </h2>
+        <p class="font-body-lg text-body-lg text-on-surface-variant mt-sm">
+          Formal certifications and accreditations held by the Leigh Services
+          team.
+        </p>
+      </header>
 
-						<section>
-							<div class="content">
-								<header>
-									<a href="https://www.comptia.org/certifications/security" target="_blank" rel="noopener noreferrer" class="icon fa-shield"><span class="label">CompTIA Security+</span></a>
-									<h3>CompTIA Security+</h3>
-								</header>
-								<p class="cert-holder">Mark Leigh</p>
-								<p class="cert-body">CompTIA Security+ &middot; Optima Training &middot; 2026</p>
-								<p>Globally recognised baseline security certification covering threat management, cryptography, identity management, network security and compliance. A foundation for Mark's DevSecOps and security-first data engineering practice.</p>
-							</div>
-						</section>
+      <div class="grid grid-cols-1 md:grid-cols-12 gap-gutter">
+        <!-- Featured: Microsoft 365 & Azure (Luke) -->
+        <div
+          class="md:col-span-8 certification-card rounded-xl p-lg flex flex-col justify-between"
+        >
+          <div>
+            <div class="flex justify-between items-start mb-md">
+              <div class="bg-primary-container/10 p-sm rounded-lg">
+                <span
+                  class="material-symbols-outlined text-primary-fixed-dim text-3xl"
+                  >cloud_done</span
+                >
+              </div>
+              <span
+                class="font-label-sm text-label-sm text-primary-fixed-dim bg-primary-container/20 px-sm py-xs rounded"
+                >PLATFORM EXPERTISE</span
+              >
+            </div>
+            <h3
+              class="font-headline-lg text-headline-lg text-on-background mb-xs"
+            >
+              Microsoft 365 &amp; Azure
+            </h3>
+            <p
+              class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-wider mb-sm"
+            >
+              Luke Leigh · 25+ years Microsoft platform experience
+            </p>
+            <p
+              class="font-body-sm text-body-sm text-on-surface-variant max-w-2xl mb-md"
+            >
+              Deep hands-on expertise across the Microsoft stack — Windows
+              Server, Active Directory, Exchange Online, Microsoft 365, Azure
+              and Entra ID. Luke has delivered M365 migrations, Exchange
+              deployments and Azure integrations across multiple organisations.
+            </p>
+            <a
+              class="inline-flex items-center gap-xs text-primary-fixed-dim hover:text-primary font-label-md text-label-md uppercase tracking-wider"
+              href="https://www.microsoft.com/en-gb/microsoft-365"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              microsoft.com/microsoft-365
+              <span class="material-symbols-outlined text-[14px]"
+                >arrow_outward</span
+              >
+            </a>
+          </div>
+          <div class="flex items-center gap-sm mt-md">
+            <div
+              class="h-1 w-full bg-surface-container rounded-full overflow-hidden"
+            >
+              <div class="h-full bg-primary-fixed-dim w-full"></div>
+            </div>
+            <span
+              class="font-label-sm text-label-sm text-primary-fixed-dim shrink-0"
+              >ACTIVE</span
+            >
+          </div>
+        </div>
 
-						<section>
-							<div class="content">
-								<header>
-									<a href="https://www.crest-approved.org/examination/crest-practitioner-security-analyst/" target="_blank" rel="noopener noreferrer" class="icon fa-lock"><span class="label">CREST CPSA</span></a>
-									<h3>CREST CPSA</h3>
-								</header>
-								<p class="cert-holder">Mark Leigh (in progress)</p>
-								<p class="cert-body">CREST Practitioner Security Analyst &middot; Optima Training</p>
-								<p>CREST Practitioner Security Analyst — a rigorous UK-based cyber security certification covering penetration testing, vulnerability assessment and security analysis. Currently in progress.</p>
-							</div>
-						</section>
+        <!-- Google Cloud Platform (Mark) -->
+        <div
+          class="md:col-span-4 certification-card rounded-xl p-lg flex flex-col"
+        >
+          <div class="bg-secondary-container/10 p-sm rounded-lg w-fit mb-md">
+            <span class="material-symbols-outlined text-secondary text-3xl"
+              >filter_drama</span
+            >
+          </div>
+          <h3 class="font-title-md text-title-md text-on-background mb-xs">
+            Google Cloud Platform
+          </h3>
+          <p
+            class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-wider mb-sm"
+          >
+            Mark Leigh
+          </p>
+          <p
+            class="font-body-sm text-body-sm text-on-surface-variant flex-grow"
+          >
+            Production GCP delivery at Swarovski (2020–2024) covering BigQuery,
+            Cloud Storage, Dataflow and GCP security — migrating a complex data
+            platform from SAS to GCP and delivering €1m in annual cost savings.
+          </p>
+          <div
+            class="mt-md flex items-center justify-between border-t border-outline-variant pt-md"
+          >
+            <a
+              class="font-label-md text-label-md text-on-surface-variant hover:text-primary"
+              href="https://cloud.google.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              >cloud.google.com</a
+            >
+            <span class="material-symbols-outlined text-primary-fixed-dim"
+              >verified</span
+            >
+          </div>
+        </div>
 
-						<section>
-							<div class="content">
-								<header>
-									<a href="https://www.microsoft.com/en-gb/microsoft-365" target="_blank" rel="noopener noreferrer" class="icon fa-windows"><span class="label">Microsoft 365</span></a>
-									<h3>Microsoft 365 &amp; Azure</h3>
-								</header>
-								<p class="cert-holder">Luke Leigh</p>
-								<p class="cert-body">25+ years Microsoft platform experience</p>
-								<p>Deep hands-on expertise across the Microsoft stack — Windows Server, Active Directory, Exchange Online, Microsoft 365, Azure and Entra ID. Luke has delivered M365 migrations, Exchange deployments and Azure integrations across multiple organisations.</p>
-							</div>
-						</section>
+        <!-- PowerShell Gallery Publisher (Luke) -->
+        <div
+          class="md:col-span-4 certification-card rounded-xl p-lg flex flex-col"
+        >
+          <div class="bg-surface-container-high p-sm rounded-lg w-fit mb-md">
+            <span
+              class="material-symbols-outlined text-on-surface-variant text-3xl"
+              >deployed_code</span
+            >
+          </div>
+          <h3 class="font-title-md text-title-md text-on-background mb-xs">
+            PowerShell Gallery Publisher
+          </h3>
+          <p
+            class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-wider mb-sm"
+          >
+            Luke Leigh
+          </p>
+          <p
+            class="font-body-sm text-body-sm text-on-surface-variant flex-grow"
+          >
+            Luke publishes open-source PowerShell modules on the PowerShell
+            Gallery — including PSCiscoMeraki. All modules are available under
+            permissive licences and reflect production-grade tooling standards.
+          </p>
+          <div
+            class="mt-md pt-md border-t border-outline-variant flex justify-between items-center"
+          >
+            <a
+              class="font-label-md text-label-md text-on-surface-variant hover:text-primary"
+              href="https://www.powershellgallery.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              >powershellgallery.com</a
+            >
+            <span class="material-symbols-outlined text-primary-fixed-dim"
+              >check_circle</span
+            >
+          </div>
+        </div>
 
-						<section>
-							<div class="content">
-								<header>
-									<a href="https://cloud.google.com/" target="_blank" rel="noopener noreferrer" class="icon fa-cloud"><span class="label">Google Cloud Platform</span></a>
-									<h3>Google Cloud Platform</h3>
-								</header>
-								<p class="cert-holder">Mark Leigh</p>
-								<p class="cert-body">Production GCP delivery &middot; Swarovski &middot; 2020&ndash;2024</p>
-								<p>Practical production experience delivering a complex data platform migration from SAS to GCP at Swarovski — covering BigQuery, Cloud Storage, Dataflow and GCP security — resulting in €1m in annual cost savings.</p>
-							</div>
-						</section>
+        <!-- GitHub Open Source (Luke) -->
+        <div
+          class="md:col-span-4 certification-card rounded-xl p-lg flex flex-col"
+        >
+          <div class="bg-surface-container-high p-sm rounded-lg w-fit mb-md">
+            <span
+              class="material-symbols-outlined text-on-surface-variant text-3xl"
+              >code</span
+            >
+          </div>
+          <h3 class="font-title-md text-title-md text-on-background mb-xs">
+            GitHub Open Source
+          </h3>
+          <p
+            class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-wider mb-sm"
+          >
+            Luke Leigh · github.com/BanterBoy
+          </p>
+          <p
+            class="font-body-sm text-body-sm text-on-surface-variant flex-grow"
+          >
+            Active GitHub contributor publishing PowerShell tooling,
+            infrastructure scripts and automation solutions. Open-source work
+            spans Cisco Meraki API integration, Active Directory utilities and
+            general infrastructure tooling.
+          </p>
+          <div
+            class="mt-md pt-md border-t border-outline-variant flex justify-between items-center"
+          >
+            <a
+              class="font-label-md text-label-md text-on-surface-variant hover:text-primary"
+              href="https://github.com/BanterBoy"
+              target="_blank"
+              rel="noopener noreferrer"
+              >github.com/BanterBoy</a
+            >
+            <span class="material-symbols-outlined text-primary-fixed-dim"
+              >verified</span
+            >
+          </div>
+        </div>
 
-						<section>
-							<div class="content">
-								<header>
-									<a href="https://www.powershellgallery.com/" target="_blank" rel="noopener noreferrer" class="icon fa-cube"><span class="label">PowerShell Gallery</span></a>
-									<h3>PowerShell Gallery Publisher</h3>
-								</header>
-								<p class="cert-holder">Luke Leigh</p>
-								<p class="cert-body">Open-source PowerShell tooling</p>
-								<p>Luke publishes open-source PowerShell modules on the PowerShell Gallery — including PSCiscoMeraki. All modules are available under permissive licences and reflect production-grade tooling standards.</p>
-							</div>
-						</section>
+        <!-- CompTIA Security+ (Mark) -->
+        <div
+          class="md:col-span-6 certification-card rounded-xl p-lg flex flex-col relative overflow-hidden group"
+        >
+          <div
+            class="absolute -right-4 -bottom-4 opacity-10 group-hover:opacity-20 transition-opacity pointer-events-none"
+          >
+            <span
+              class="material-symbols-outlined text-[120px] text-primary-fixed-dim"
+              >gpp_good</span
+            >
+          </div>
+          <div class="bg-error-container/20 p-sm rounded-lg w-fit mb-md">
+            <span class="material-symbols-outlined text-error text-3xl"
+              >shield_lock</span
+            >
+          </div>
+          <h3
+            class="font-headline-lg text-headline-lg text-on-background mb-xs"
+          >
+            CompTIA Security+
+          </h3>
+          <p
+            class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-wider mb-sm"
+          >
+            Mark Leigh · Optima Training · 2026
+          </p>
+          <p
+            class="font-body-sm text-body-sm text-on-surface-variant mb-md pr-12"
+          >
+            Globally recognised baseline security certification covering threat
+            management, cryptography, identity management, network security and
+            compliance. A foundation for Mark's DevSecOps and security-first
+            data engineering practice.
+          </p>
+          <div class="mt-auto flex items-center justify-between gap-md">
+            <span
+              class="font-label-md text-label-md text-on-error-container bg-error-container/30 px-sm py-xs rounded"
+              >VERIFIED ENGINEER</span
+            >
+            <a
+              class="inline-flex items-center gap-xs text-primary-fixed-dim hover:text-primary font-label-md text-label-md uppercase tracking-wider"
+              href="https://www.comptia.org/certifications/security"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              comptia.org
+              <span class="material-symbols-outlined text-[14px]"
+                >arrow_outward</span
+              >
+            </a>
+          </div>
+        </div>
 
-						<section>
-							<div class="content">
-								<header>
-									<a href="https://github.com/BanterBoy" target="_blank" rel="noopener noreferrer" class="icon fa-github"><span class="label">GitHub</span></a>
-									<h3>GitHub Open Source</h3>
-								</header>
-								<p class="cert-holder">Luke Leigh</p>
-								<p class="cert-body">github.com/BanterBoy</p>
-								<p>Active GitHub contributor publishing PowerShell tooling, infrastructure scripts and automation solutions. Open-source work spans Cisco Meraki API integration, Active Directory utilities and general infrastructure tooling.</p>
-							</div>
-						</section>
+        <!-- Ongoing & Candidate Status -->
+        <div
+          class="md:col-span-6 bg-surface-container-highest border border-outline-variant rounded-xl p-lg flex flex-col"
+        >
+          <h3
+            class="font-title-md text-title-md text-on-background mb-lg flex items-center gap-sm"
+          >
+            <span class="material-symbols-outlined text-primary-fixed-dim"
+              >pending_actions</span
+            >
+            Ongoing &amp; Candidate Status
+          </h3>
+          <div class="space-y-md">
+            <!-- CREST CPSA -->
+            <div
+              class="p-md bg-surface-container rounded-lg border-l-4 border-primary-fixed-dim"
+            >
+              <div class="flex justify-between items-start gap-md">
+                <div>
+                  <h4 class="font-title-md text-on-background">CREST CPSA</h4>
+                  <p
+                    class="font-label-md text-label-md text-on-surface-variant"
+                  >
+                    CREST Practitioner Security Analyst · Mark Leigh · Optima
+                    Training
+                  </p>
+                </div>
+                <span
+                  class="font-label-sm text-label-sm text-primary-fixed-dim animate-pulse shrink-0"
+                  >IN PROGRESS</span
+                >
+              </div>
+              <p
+                class="font-body-sm text-body-sm text-on-surface-variant mt-sm"
+              >
+                A rigorous UK-based cyber security certification covering
+                penetration testing, vulnerability assessment and security
+                analysis. Currently in progress.
+              </p>
+              <div
+                class="mt-md h-2 bg-surface-container-low rounded-full overflow-hidden"
+              >
+                <div
+                  class="h-full bg-primary-fixed-dim w-1/2 rounded-full"
+                ></div>
+              </div>
+              <a
+                class="inline-flex items-center gap-xs mt-sm text-primary-fixed-dim hover:text-primary font-label-md text-label-md uppercase tracking-wider"
+                href="https://www.crest-approved.org/examination/crest-practitioner-security-analyst/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                crest-approved.org
+                <span class="material-symbols-outlined text-[14px]"
+                  >arrow_outward</span
+                >
+              </a>
+            </div>
 
-					</div>
+            <!-- BSc Applied Computer Science -->
+            <div
+              class="p-md bg-surface-container rounded-lg border-l-4 border-primary-fixed-dim"
+            >
+              <div class="flex justify-between items-start gap-md">
+                <div>
+                  <h4 class="font-title-md text-on-background">
+                    BSc Applied Computer Science
+                  </h4>
+                  <p
+                    class="font-label-md text-label-md text-on-surface-variant"
+                  >
+                    Mark Leigh · De Montfort University, Leicester
+                  </p>
+                </div>
+                <span
+                  class="font-label-sm text-label-sm text-primary-fixed-dim animate-pulse shrink-0"
+                  >ACADEMIC</span
+                >
+              </div>
+              <p
+                class="font-body-sm text-body-sm text-on-surface-variant mt-sm"
+              >
+                Bachelor of Science in Applied Computer Science — providing the
+                academic foundation for Mark's subsequent career in data
+                engineering, security and platform development spanning 20+
+                years.
+              </p>
+              <div
+                class="mt-md h-2 bg-surface-container-low rounded-full overflow-hidden"
+              >
+                <div
+                  class="h-full bg-primary-fixed-dim w-full rounded-full"
+                ></div>
+              </div>
+              <a
+                class="inline-flex items-center gap-xs mt-sm text-primary-fixed-dim hover:text-primary font-label-md text-label-md uppercase tracking-wider"
+                href="https://www.dmu.ac.uk/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                dmu.ac.uk
+                <span class="material-symbols-outlined text-[14px]"
+                  >arrow_outward</span
+                >
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
 
-					<header class="special" style="margin-top:4em;">
-						<h2>Academic Credentials</h2>
-					</header>
-					<div class="highlights">
+      <!-- Call to Action -->
+      <section
+        class="mt-xl text-center p-xl rounded-xl border border-outline-variant bg-gradient-to-br from-surface-container-low to-surface-container-lowest"
+      >
+        <h2 class="font-headline-lg text-headline-lg text-on-background mb-md">
+          Ready to deploy certified expertise?
+        </h2>
+        <p
+          class="font-body-lg text-body-lg text-on-surface-variant mb-xl max-w-xl mx-auto"
+        >
+          Leverage our certified, security-first engineering for your next
+          infrastructure, automation or data platform project.
+        </p>
+        <div class="flex flex-col sm:flex-row justify-center gap-md">
+          <a
+            class="bg-primary-container text-on-primary-container px-xl py-md rounded font-bold glow-button transition-all"
+            href="contact.html"
+            >Start a Consultation</a
+          >
+          <a
+            class="border border-outline text-primary-fixed-dim px-xl py-md rounded font-bold hover:bg-primary-container/10 transition-all"
+            href="services.html"
+            >View Services</a
+          >
+        </div>
+      </section>
+    </main>
 
-						<section>
-							<div class="content">
-								<header>
-									<a href="https://www.dmu.ac.uk/" target="_blank" rel="noopener noreferrer" class="icon fa-graduation-cap"><span class="label">De Montfort University</span></a>
-									<h3>BSc Applied Computer Science</h3>
-								</header>
-								<p class="cert-holder">Mark Leigh</p>
-								<p class="cert-body">De Montfort University, Leicester</p>
-								<p>Bachelor of Science in Applied Computer Science — providing the academic foundation for Mark's subsequent career in data engineering, security and platform development spanning 20+ years.</p>
-							</div>
-						</section>
+    <!-- Footer -->
+    <footer
+      class="bg-surface-container-lowest border-t border-outline-variant mt-xl"
+    >
+      <div
+        class="grid grid-cols-1 md:grid-cols-4 gap-xl px-lg py-xl max-w-7xl mx-auto"
+      >
+        <div class="space-y-md">
+          <h3
+            class="font-title-md text-title-md font-bold text-primary-fixed-dim"
+          >
+            Leigh Services
+          </h3>
+          <p
+            class="font-body-sm text-body-sm text-on-surface-variant leading-relaxed"
+          >
+            Expert IT Infrastructure, Automation and Data Engineering consulting
+            based in Southend-on-Sea, Essex. Serving clients across the UK and
+            internationally.
+          </p>
+          <p
+            class="font-body-sm text-body-sm text-on-surface-variant leading-relaxed"
+          >
+            63 Archer Avenue, Southend on Sea,<br />Essex SS2 4QU
+          </p>
+        </div>
+        <div class="space-y-sm">
+          <h4
+            class="font-label-md text-label-md text-primary font-bold uppercase"
+          >
+            Services
+          </h4>
+          <ul
+            class="space-y-xs font-body-sm text-body-sm text-on-surface-variant"
+          >
+            <li>
+              <a
+                class="hover:text-primary transition-colors"
+                href="services.html#it-infrastructure"
+                >IT Infrastructure</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary transition-colors"
+                href="services.html#powershell-automation"
+                >PowerShell &amp; Automation</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary transition-colors"
+                href="services.html#cloud-solutions"
+                >Cloud Solutions</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary transition-colors"
+                href="services.html#data-engineering"
+                >Data Engineering</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary transition-colors"
+                href="services.html#security-compliance"
+                >Security &amp; Compliance</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary transition-colors"
+                href="services.html#devsecops"
+                >DevSecOps</a
+              >
+            </li>
+          </ul>
+        </div>
+        <div class="space-y-sm">
+          <h4
+            class="font-label-md text-label-md text-primary font-bold uppercase"
+          >
+            Navigation
+          </h4>
+          <ul
+            class="space-y-xs font-body-sm text-body-sm text-on-surface-variant"
+          >
+            <li>
+              <a class="hover:text-primary transition-colors" href="team.html"
+                >Meet the Team</a
+              >
+            </li>
+            <li>
+              <a
+                class="text-primary-fixed-dim font-bold"
+                href="certifications.html"
+                >Certifications</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary transition-colors"
+                href="case-studies.html"
+                >Case Studies</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary transition-colors"
+                href="contact.html"
+                >Contact</a
+              >
+            </li>
+          </ul>
+        </div>
+        <div class="space-y-sm">
+          <h4
+            class="font-label-md text-label-md text-primary font-bold uppercase"
+          >
+            Connect
+          </h4>
+          <ul
+            class="space-y-xs font-body-sm text-body-sm text-on-surface-variant"
+          >
+            <li>
+              <a
+                class="flex items-center gap-xs hover:text-primary transition-colors"
+                href="https://www.linkedin.com/in/lukeleigh"
+                target="_blank"
+                rel="noopener noreferrer"
+                ><span class="material-symbols-outlined text-[16px]">link</span>
+                Luke on LinkedIn</a
+              >
+            </li>
+            <li>
+              <a
+                class="flex items-center gap-xs hover:text-primary transition-colors"
+                href="https://www.linkedin.com/in/markleigh"
+                target="_blank"
+                rel="noopener noreferrer"
+                ><span class="material-symbols-outlined text-[16px]">link</span>
+                Mark on LinkedIn</a
+              >
+            </li>
+            <li>
+              <a
+                class="flex items-center gap-xs hover:text-primary transition-colors"
+                href="https://github.com/BanterBoy"
+                target="_blank"
+                rel="noopener noreferrer"
+                ><span class="material-symbols-outlined text-[16px]"
+                  >terminal</span
+                >
+                GitHub (BanterBoy)</a
+              >
+            </li>
+            <li>
+              <a
+                class="flex items-center gap-xs hover:text-primary transition-colors"
+                href="https://blog.lukeleigh.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                ><span class="material-symbols-outlined text-[16px]"
+                  >rss_feed</span
+                >
+                Luke's Blog</a
+              >
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div
+        class="max-w-7xl mx-auto px-lg py-md border-t border-outline-variant/30 flex flex-col md:flex-row justify-between items-center gap-md"
+      >
+        <p class="font-body-sm text-body-sm text-on-surface-variant opacity-70">
+          © 2024–2026 Leigh IT Services Ltd. All rights reserved.
+        </p>
+        <div
+          class="flex gap-md font-body-sm text-body-sm text-on-surface-variant opacity-70"
+        >
+          <a class="hover:text-primary" href="#">Privacy Policy</a>
+          <a class="hover:text-primary" href="#">Terms of Service</a>
+        </div>
+      </div>
+    </footer>
 
-					</div>
-				</div>
-			</section>
-
-		<!-- Footer -->
-			<footer id="footer">
-				<div class="inner">
-					<div class="content">
-						<section>
-							<h3>Leigh Services</h3>
-							<p>Expert IT Infrastructure, Automation and Data Engineering consulting based in Southend-on-Sea, Essex. Serving clients across the UK and internationally.</p>
-							<p>63 Archer Avenue, Southend on Sea, Essex SS2 4QU</p>
-						</section>
-						<section>
-							<h4>Services</h4>
-							<ul class="alt">
-								<li><a href="services.html#it-infrastructure">IT Infrastructure</a></li>
-								<li><a href="services.html#powershell-automation">PowerShell &amp; Automation</a></li>
-								<li><a href="services.html#cloud-solutions">Cloud Solutions</a></li>
-								<li><a href="services.html#data-engineering">Data Engineering</a></li>
-								<li><a href="services.html#security-compliance">Security &amp; Compliance</a></li>
-								<li><a href="services.html#devsecops">DevSecOps</a></li>
-							</ul>
-						</section>
-						<section>
-							<h4>Connect</h4>
-							<ul class="plain">
-								<li><a href="https://www.linkedin.com/in/lukeleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>Luke on LinkedIn</a></li>
-								<li><a href="https://www.linkedin.com/in/markleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>Mark on LinkedIn</a></li>
-								<li><a href="https://github.com/BanterBoy" target="_blank" rel="noopener noreferrer"><i class="icon fa-github">&nbsp;</i>GitHub (BanterBoy)</a></li>
-								<li><a href="https://blog.lukeleigh.com" target="_blank" rel="noopener noreferrer"><i class="icon fa-rss">&nbsp;</i>Luke's Blog</a></li>
-							</ul>
-						</section>
-					</div>
-					<div class="copyright">
-						&copy; 2024&ndash;2026 Leigh IT Services Ltd. All rights reserved.
-					</div>
-				</div>
-			</footer>
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
-
-	</body>
+    <!-- Micro-interaction Script -->
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        const cards = document.querySelectorAll(".certification-card");
+        cards.forEach((card) => {
+          card.addEventListener("mousemove", (e) => {
+            const rect = card.getBoundingClientRect();
+            const x = e.clientX - rect.left;
+            const y = e.clientY - rect.top;
+            card.style.setProperty("--mouse-x", `${x}px`);
+            card.style.setProperty("--mouse-y", `${y}px`);
+          });
+        });
+      });
+    </script>
+  </body>
 </html>

--- a/certifications.html
+++ b/certifications.html
@@ -923,8 +923,8 @@
         <div
           class="flex gap-md font-body-sm text-body-sm text-on-surface-variant opacity-70"
         >
-          <a class="hover:text-primary" href="#">Privacy Policy</a>
-          <a class="hover:text-primary" href="#">Terms of Service</a>
+          <span>Privacy Policy</span>
+          <span>Terms of Service</span>
         </div>
       </div>
     </footer>

--- a/contact.html
+++ b/contact.html
@@ -1,249 +1,746 @@
-<!DOCTYPE HTML>
-<html lang="en-gb">
-	<head>
-		<title>Get In Touch | Leigh Services</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<meta name="description" content="Get in touch with Leigh Services to discuss your IT infrastructure, automation, data engineering or security compliance project." />
-		<meta name="keywords" content="contact Leigh Services, IT consulting, infrastructure, PowerShell, data engineering, Essex, UK" />
-		<meta property="og:title" content="Get In Touch | Leigh Services" />
-		<meta property="og:description" content="Contact Leigh Services to discuss your next project." />
-		<meta property="og:url" content="https://leigh-services.com/contact.html" />
-		<meta property="og:image" content="https://leigh-services.com/images/banner.jpg" />
-		<meta property="og:type" content="website" />
-		<meta property="og:site_name" content="Leigh Services" />
-		<meta http-equiv="content-language" content="en-gb" />
-		<link rel="canonical" href="https://leigh-services.com/contact.html" />
-		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Get In Touch | Leigh Services" />
-		<meta name="twitter:description" content="Contact Leigh Services to discuss your next project." />
-		<meta name="twitter:image" content="https://leigh-services.com/images/banner.jpg" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<style>
-			.contact-layout {
-				display: -ms-flexbox;
-				display: flex;
-				-ms-flex-wrap: wrap;
-				flex-wrap: wrap;
-				gap: 4em;
-				align-items: flex-start;
-			}
-			.contact-form-col {
-				-ms-flex: 2 1 400px;
-				flex: 2 1 400px;
-			}
-			.contact-info-col {
-				-ms-flex: 1 1 240px;
-				flex: 1 1 240px;
-			}
-			.contact-info-col h4 {
-				font-size: 0.85em;
-				text-transform: uppercase;
-				letter-spacing: 0.1em;
-				color: #111;
-				margin-bottom: 0.6em;
-			}
-			.contact-info-col p {
-				font-size: 0.9em;
-				color: #555;
-				line-height: 1.7;
-				margin-bottom: 1.4em;
-			}
-			.contact-info-col ul {
-				list-style: none;
-				margin: 0;
-				padding: 0;
-			}
-			.contact-info-col ul li {
-				margin-bottom: 0.6em;
-				font-size: 0.9em;
-			}
-			.contact-info-col ul li a {
-				color: #ce1b28;
-				text-decoration: none;
-				font-weight: 600;
-			}
-			.contact-info-col ul li a:hover {
-				text-decoration: underline;
-			}
-			.map-wrap {
-				margin-top: 3em;
-				border-radius: 4px;
-				overflow: hidden;
-				box-shadow: 0 2px 12px rgba(0,0,0,0.10);
-			}
-			.map-wrap iframe {
-				display: block;
-				width: 100%;
-				height: 340px;
-				border: 0;
-			}
-		</style>
-		<script src="assets/js/metrics.js"></script>
-	</head>
-	<body class="is-preload">
-		<!-- Google Tag Manager (noscript) -->
-		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-		<!-- End Google Tag Manager (noscript) -->
+<!doctype html>
 
-		<!-- Header -->
-			<header id="header">
-				<a class="logo" href="index.html">Leigh Services</a>
-				<nav>
-					<a href="#menu">Menu</a>
-				</nav>
-			</header>
+<html class="dark" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Get In Touch | Leigh Services</title>
+    <meta
+      name="description"
+      content="Get in touch with Leigh Services to discuss your IT infrastructure, automation, data engineering or security compliance project."
+    />
+    <meta
+      name="keywords"
+      content="contact Leigh Services, IT consulting, infrastructure, PowerShell, data engineering, Essex, UK"
+    />
+    <meta property="og:title" content="Get In Touch | Leigh Services" />
+    <meta
+      property="og:description"
+      content="Contact Leigh Services to discuss your next project."
+    />
+    <meta property="og:url" content="https://leigh-services.com/contact.html" />
+    <meta
+      property="og:image"
+      content="https://leigh-services.com/images/banner.jpg"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Leigh Services" />
+    <meta http-equiv="content-language" content="en-gb" />
+    <link rel="canonical" href="https://leigh-services.com/contact.html" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Get In Touch | Leigh Services" />
+    <meta
+      name="twitter:description"
+      content="Contact Leigh Services to discuss your next project."
+    />
+    <meta
+      name="twitter:image"
+      content="https://leigh-services.com/images/banner.jpg"
+    />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&amp;family=Geist:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <script id="tailwind-config">
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            colors: {
+              "surface-container-low": "#131c2b",
+              "outline-variant": "#3b494c",
+              "on-error": "#690005",
+              "on-tertiary-fixed": "#001945",
+              "surface-container-lowest": "#060e1d",
+              "on-background": "#dbe2f8",
+              "error-container": "#93000a",
+              "on-secondary": "#1b247f",
+              "surface-tint": "#00daf3",
+              "tertiary-container": "#bfd0ff",
+              "primary-container": "#00e5ff",
+              "on-tertiary-fixed-variant": "#00429c",
+              "on-secondary-fixed-variant": "#343d96",
+              "inverse-surface": "#dbe2f8",
+              "inverse-primary": "#006875",
+              "surface-container": "#18202f",
+              surface: "#0b1323",
+              "on-primary-container": "#00626e",
+              "on-primary-fixed": "#001f24",
+              error: "#ffb4ab",
+              "surface-container-high": "#222a3a",
+              "secondary-fixed": "#e0e0ff",
+              "on-secondary-container": "#a8afff",
+              "tertiary-fixed-dim": "#b0c6ff",
+              "secondary-container": "#343d96",
+              "primary-fixed-dim": "#00daf3",
+              tertiary: "#e8ecff",
+              "on-tertiary-container": "#2455af",
+              "on-primary-fixed-variant": "#004f58",
+              "on-secondary-fixed": "#000767",
+              primary: "#c3f5ff",
+              background: "#0b1323",
+              "on-tertiary": "#002d6f",
+              "on-primary": "#00363d",
+              "on-error-container": "#ffdad6",
+              "inverse-on-surface": "#283041",
+              "surface-variant": "#2d3546",
+              "surface-container-highest": "#2d3546",
+              secondary: "#bdc2ff",
+              outline: "#849396",
+              "on-surface-variant": "#bac9cc",
+              "surface-bright": "#31394a",
+              "primary-fixed": "#9cf0ff",
+              "tertiary-fixed": "#d9e2ff",
+              "surface-dim": "#0b1323",
+              "on-surface": "#dbe2f8",
+              "secondary-fixed-dim": "#bdc2ff",
+            },
+            borderRadius: {
+              DEFAULT: "0.125rem",
+              lg: "0.25rem",
+              xl: "0.5rem",
+              full: "0.75rem",
+            },
+            spacing: {
+              xs: "4px",
+              margin: "24px",
+              lg: "24px",
+              xl: "40px",
+              gutter: "16px",
+              base: "4px",
+              sm: "8px",
+              md: "16px",
+            },
+            fontFamily: {
+              "headline-lg-mobile": ["Geist"],
+              "title-md": ["Geist"],
+              "label-sm": ["JetBrains Mono"],
+              "headline-lg": ["Geist"],
+              "body-sm": ["Geist"],
+              "label-md": ["JetBrains Mono"],
+              "body-lg": ["Geist"],
+              "display-lg": ["Geist"],
+            },
+            fontSize: {
+              "headline-lg-mobile": [
+                "24px",
+                { lineHeight: "32px", fontWeight: "600" },
+              ],
+              "title-md": ["20px", { lineHeight: "28px", fontWeight: "500" }],
+              "label-sm": [
+                "10px",
+                {
+                  lineHeight: "14px",
+                  letterSpacing: "0.05em",
+                  fontWeight: "500",
+                },
+              ],
+              "headline-lg": [
+                "32px",
+                { lineHeight: "40px", fontWeight: "600" },
+              ],
+              "body-sm": ["14px", { lineHeight: "20px", fontWeight: "400" }],
+              "label-md": [
+                "12px",
+                {
+                  lineHeight: "16px",
+                  letterSpacing: "0.05em",
+                  fontWeight: "500",
+                },
+              ],
+              "body-lg": ["16px", { lineHeight: "24px", fontWeight: "400" }],
+              "display-lg": [
+                "48px",
+                {
+                  lineHeight: "56px",
+                  letterSpacing: "-0.02em",
+                  fontWeight: "700",
+                },
+              ],
+            },
+          },
+        },
+      };
+    </script>
+    <style>
+      body {
+        background-color: #0b1323;
+        color: #dbe2f8;
+        font-family: "Geist", sans-serif;
+      }
+      .material-symbols-outlined {
+        font-variation-settings:
+          "FILL" 0,
+          "wght" 400,
+          "GRAD" 0,
+          "opsz" 24;
+        display: inline-block;
+        vertical-align: middle;
+      }
+      /* Style native select dropdown to match dark theme */
+      select option {
+        background-color: #131c2b;
+        color: #dbe2f8;
+      }
+    </style>
+    <script src="assets/js/metrics.js"></script>
+  </head>
+  <body
+    class="bg-background text-on-background font-body-lg overflow-x-hidden selection:bg-primary-container selection:text-on-primary-container"
+  >
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden"
+      ></iframe>
+    </noscript>
 
-		<!-- Nav -->
-			<nav id="menu">
-				<ul class="links">
-					<li><a href="index.html">Home</a></li>
-					<li><a href="services.html">Services</a></li>
-					<li><a href="team.html">Meet the Team</a></li>
-					<li><a href="certifications.html">Certifications</a></li>
-					<li><a href="case-studies.html">Case Studies</a></li>
-					<li><a href="testimonials.html">Testimonials</a></li>
-					<li><a href="blog.html">Blog</a></li>
-					<li><a href="contact.html">Contact</a></li>
-				</ul>
-			</nav>
+    <!-- Navigation Header -->
+    <nav
+      class="bg-surface-container-lowest border-b border-outline-variant sticky top-0 z-[100] w-full"
+    >
+      <div
+        class="flex justify-between items-center px-lg py-md w-full max-w-7xl mx-auto"
+      >
+        <a
+          class="font-headline-lg text-headline-lg font-bold text-primary-fixed-dim tracking-tight"
+          href="index.html"
+          >Leigh Services</a
+        >
+        <!-- Desktop Links -->
+        <div class="hidden md:flex items-center gap-lg">
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="index.html"
+            >Home</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="services.html"
+            >Services</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="team.html"
+            >Meet the Team</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="certifications.html"
+            >Certifications</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="case-studies.html"
+            >Case Studies</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="testimonials.html"
+            >Testimonials</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="blog.html"
+            >Blog</a
+          >
+          <a
+            class="text-primary-fixed-dim font-bold border-b-2 border-primary-fixed-dim pb-1"
+            href="contact.html"
+            >Contact</a
+          >
+          <a
+            class="ml-md bg-primary-container text-on-primary-fixed px-md py-sm rounded font-bold hover:opacity-80 transition-all"
+            href="contact.html"
+          >
+            Consultation
+          </a>
+        </div>
+        <!-- Mobile Menu Toggle -->
+        <button
+          class="md:hidden text-primary-fixed-dim"
+          onclick="
+            document.getElementById('mobile-menu').classList.toggle('hidden')
+          "
+        >
+          <span class="material-symbols-outlined">menu</span>
+        </button>
+      </div>
+    </nav>
+    <!-- Mobile Menu -->
+    <div
+      class="hidden md:hidden fixed inset-0 z-[110] bg-surface-container-lowest p-lg"
+      id="mobile-menu"
+    >
+      <div class="flex flex-col gap-md">
+        <div class="flex justify-between items-center mb-xl">
+          <span
+            class="font-headline-lg-mobile text-headline-lg-mobile text-primary-fixed-dim"
+            >Leigh Services</span
+          >
+          <button
+            onclick="
+              document.getElementById('mobile-menu').classList.add('hidden')
+            "
+          >
+            <span class="material-symbols-outlined">close</span>
+          </button>
+        </div>
+        <a class="text-title-md py-sm" href="index.html">Home</a>
+        <a class="text-title-md py-sm" href="services.html">Services</a>
+        <a class="text-title-md py-sm" href="team.html">Meet the Team</a>
+        <a class="text-title-md py-sm" href="certifications.html"
+          >Certifications</a
+        >
+        <a class="text-title-md py-sm" href="case-studies.html">Case Studies</a>
+        <a class="text-title-md py-sm" href="testimonials.html">Testimonials</a>
+        <a class="text-title-md py-sm" href="blog.html">Blog</a>
+        <a
+          class="text-title-md py-sm text-primary-fixed-dim font-bold"
+          href="contact.html"
+          >Contact</a
+        >
+        <a
+          class="mt-md bg-primary-container text-on-primary-fixed text-center px-md py-md rounded font-bold"
+          href="contact.html"
+          >Consultation</a
+        >
+      </div>
+    </div>
 
-		<!-- Heading -->
-			<div id="heading">
-				<h1>Get In Touch</h1>
-			</div>
+    <main class="pt-xl pb-xl px-margin max-w-7xl mx-auto min-h-screen">
+      <!-- Hero Header -->
+      <header class="mb-xl">
+        <h1
+          class="font-display-lg text-display-lg text-primary-fixed-dim mb-md"
+        >
+          Get in Touch
+        </h1>
+        <p class="font-body-lg text-body-lg text-on-surface-variant max-w-2xl">
+          Whether you have a specific project in mind or just want to talk
+          through a challenge, we are happy to have a no-obligation
+          conversation. Fill in the form below and we will get back to you.
+        </p>
+      </header>
 
-		<!-- Main -->
-			<section id="main" class="wrapper">
-				<div class="inner">
-					<div class="content">
+      <!-- Main Content Bento Grid -->
+      <div class="grid grid-cols-1 md:grid-cols-12 gap-gutter">
+        <!-- Contact Form Card -->
+        <section
+          class="md:col-span-7 bg-surface-container border border-outline-variant rounded-xl p-lg relative overflow-hidden"
+        >
+          <div class="relative z-10">
+            <h2
+              class="font-headline-lg text-headline-lg mb-lg flex items-center gap-sm"
+            >
+              <span class="material-symbols-outlined text-primary-fixed-dim"
+                >mail</span
+              >
+              Send a Message
+            </h2>
+            <form
+              method="POST"
+              action="https://formspree.io/xvowjgjd"
+              class="space-y-md"
+            >
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-md">
+                <div class="space-y-xs">
+                  <label
+                    for="name"
+                    class="block font-label-md text-label-md text-primary-fixed-dim uppercase tracking-wider"
+                    >Full Name</label
+                  >
+                  <input
+                    id="name"
+                    name="name"
+                    type="text"
+                    required
+                    placeholder="Your name"
+                    class="w-full bg-surface-container-low border border-outline-variant focus:border-primary-container focus:ring-1 focus:ring-primary-container text-on-surface p-md rounded-lg outline-none transition-all"
+                  />
+                </div>
+                <div class="space-y-xs">
+                  <label
+                    for="email"
+                    class="block font-label-md text-label-md text-primary-fixed-dim uppercase tracking-wider"
+                    >Email Address</label
+                  >
+                  <input
+                    id="email"
+                    name="email"
+                    type="email"
+                    required
+                    placeholder="you@company.com"
+                    class="w-full bg-surface-container-low border border-outline-variant focus:border-primary-container focus:ring-1 focus:ring-primary-container text-on-surface p-md rounded-lg outline-none transition-all"
+                  />
+                </div>
+              </div>
+              <div class="space-y-xs">
+                <label
+                  for="company"
+                  class="block font-label-md text-label-md text-primary-fixed-dim uppercase tracking-wider"
+                  >Company
+                  <span
+                    class="text-on-surface-variant normal-case tracking-normal"
+                    >(optional)</span
+                  ></label
+                >
+                <input
+                  id="company"
+                  name="company"
+                  type="text"
+                  placeholder="Your organisation"
+                  class="w-full bg-surface-container-low border border-outline-variant focus:border-primary-container focus:ring-1 focus:ring-primary-container text-on-surface p-md rounded-lg outline-none transition-all"
+                />
+              </div>
+              <div class="space-y-xs">
+                <label
+                  for="service"
+                  class="block font-label-md text-label-md text-primary-fixed-dim uppercase tracking-wider"
+                  >Area of Interest</label
+                >
+                <select
+                  id="service"
+                  name="service"
+                  class="w-full bg-surface-container-low border border-outline-variant focus:border-primary-container focus:ring-1 focus:ring-primary-container text-on-surface p-md rounded-lg outline-none transition-all appearance-none"
+                >
+                  <option value="">Select a service area...</option>
+                  <option value="it-infrastructure">IT Infrastructure</option>
+                  <option value="powershell-automation">
+                    PowerShell &amp; Automation
+                  </option>
+                  <option value="cloud-solutions">Cloud Solutions</option>
+                  <option value="data-engineering">Data Engineering</option>
+                  <option value="security-compliance">
+                    Security &amp; Compliance
+                  </option>
+                  <option value="devsecops">DevSecOps</option>
+                  <option value="other">Other / General Enquiry</option>
+                </select>
+              </div>
+              <div class="space-y-xs">
+                <label
+                  for="message"
+                  class="block font-label-md text-label-md text-primary-fixed-dim uppercase tracking-wider"
+                  >Message</label
+                >
+                <textarea
+                  id="message"
+                  name="message"
+                  rows="6"
+                  placeholder="Tell us a little about what you are working on or what you need help with..."
+                  class="w-full bg-surface-container-low border border-outline-variant focus:border-primary-container focus:ring-1 focus:ring-primary-container text-on-surface p-md rounded-lg outline-none transition-all resize-none"
+                ></textarea>
+              </div>
+              <button
+                type="submit"
+                class="w-full py-md bg-primary-container text-on-primary-fixed font-bold text-lg rounded-lg shadow-[0_0_20px_rgba(0,229,255,0.3)] hover:shadow-[0_0_30px_rgba(0,229,255,0.5)] transition-all flex items-center justify-center gap-sm"
+              >
+                <span class="material-symbols-outlined">send</span>
+                Transmit Message
+              </button>
+            </form>
+          </div>
+        </section>
 
-						<header>
-							<h2>Start a Conversation</h2>
-							<p>Whether you have a specific project in mind or just want to talk through a challenge, we are happy to have a no-obligation conversation. Fill in the form below and we will get back to you.</p>
-						</header>
+        <!-- Right Column: Office & Sidebar Info -->
+        <div class="md:col-span-5 space-y-gutter">
+          <!-- Office Headquarters Card -->
+          <article
+            class="bg-surface-container-high border border-outline-variant rounded-xl p-lg group hover:border-primary-fixed-dim transition-colors"
+          >
+            <h3
+              class="font-title-md text-title-md text-primary-fixed-dim mb-md flex items-center gap-sm"
+            >
+              <span class="material-symbols-outlined">location_on</span>
+              Office Headquarters
+            </h3>
+            <p class="font-body-lg text-body-lg mb-md">
+              Leigh Services<br />
+              63 Archer Avenue,<br />
+              Southend on Sea,<br />
+              Essex SS2 4QU<br />
+              United Kingdom
+            </p>
+            <div
+              class="w-full h-48 rounded-lg overflow-hidden grayscale contrast-125 opacity-80 group-hover:grayscale-0 group-hover:opacity-100 transition-all bg-surface-container-low flex items-center justify-center border border-outline-variant"
+              aria-hidden="true"
+            >
+              <span
+                class="material-symbols-outlined text-primary-fixed-dim"
+                style="font-size: 96px"
+                >location_city</span
+              >
+            </div>
+          </article>
 
-						<div class="contact-layout">
+          <!-- Connect & Contribute Card -->
+          <article
+            class="bg-surface-container-high border border-outline-variant rounded-xl p-lg"
+          >
+            <h3
+              class="font-title-md text-title-md text-primary-fixed-dim mb-lg flex items-center gap-sm"
+            >
+              <span class="material-symbols-outlined">share</span>
+              Connect &amp; Contribute
+            </h3>
+            <div class="space-y-md">
+              <a
+                href="https://blog.lukeleigh.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="flex items-center justify-between p-md bg-surface-container rounded-lg border border-outline-variant hover:bg-secondary-container/10 transition-colors group"
+              >
+                <div class="flex items-center gap-md">
+                  <span class="material-symbols-outlined text-primary-fixed-dim"
+                    >terminal</span
+                  >
+                  <div>
+                    <p class="font-label-md text-label-md text-on-surface">
+                      Luke's Technical Blog
+                    </p>
+                    <p class="text-xs text-on-surface-variant">
+                      Infrastructure &amp; Automation Insights
+                    </p>
+                  </div>
+                </div>
+                <span
+                  class="material-symbols-outlined text-on-surface-variant group-hover:translate-x-1 transition-transform"
+                  >arrow_forward</span
+                >
+              </a>
+              <a
+                href="https://github.com/BanterBoy"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="flex items-center justify-between p-md bg-surface-container rounded-lg border border-outline-variant hover:bg-secondary-container/10 transition-colors group"
+              >
+                <div class="flex items-center gap-md">
+                  <span class="material-symbols-outlined text-primary-fixed-dim"
+                    >code</span
+                  >
+                  <div>
+                    <p class="font-label-md text-label-md text-on-surface">
+                      GitHub (BanterBoy)
+                    </p>
+                    <p class="text-xs text-on-surface-variant">
+                      Open Source PowerShell Modules
+                    </p>
+                  </div>
+                </div>
+                <span
+                  class="material-symbols-outlined text-on-surface-variant group-hover:translate-x-1 transition-transform"
+                  >arrow_forward</span
+                >
+              </a>
+              <div class="grid grid-cols-2 gap-md">
+                <a
+                  href="https://www.linkedin.com/in/lukeleigh"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="flex items-center gap-sm p-sm bg-surface-container rounded-lg border border-outline-variant hover:text-primary-fixed-dim transition-colors"
+                >
+                  <span class="material-symbols-outlined text-sm">link</span>
+                  <span class="font-label-md">Luke Leigh</span>
+                </a>
+                <a
+                  href="https://www.linkedin.com/in/markleigh"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="flex items-center gap-sm p-sm bg-surface-container rounded-lg border border-outline-variant hover:text-primary-fixed-dim transition-colors"
+                >
+                  <span class="material-symbols-outlined text-sm">link</span>
+                  <span class="font-label-md">Mark Leigh</span>
+                </a>
+              </div>
+            </div>
+          </article>
 
-							<!-- Form -->
-							<div class="contact-form-col">
-								<form method="post" action="https://formspree.io/xvowjgjd">
-									<div class="fields">
-										<div class="field half">
-											<label for="name">Name</label>
-											<input type="text" name="name" id="name" placeholder="Your name" required />
-										</div>
-										<div class="field half">
-											<label for="email">Email</label>
-											<input type="email" name="email" id="email" placeholder="Your email address" required />
-										</div>
-										<div class="field">
-											<label for="company">Company <span style="font-weight:400; color:#888;">(optional)</span></label>
-											<input type="text" name="company" id="company" placeholder="Your organisation" />
-										</div>
-										<div class="field">
-											<label for="service">Area of Interest</label>
-											<select name="service" id="service">
-												<option value="">Select a service area...</option>
-												<option value="it-infrastructure">IT Infrastructure</option>
-												<option value="powershell-automation">PowerShell &amp; Automation</option>
-												<option value="cloud-solutions">Cloud Solutions</option>
-												<option value="data-engineering">Data Engineering</option>
-												<option value="security-compliance">Security &amp; Compliance</option>
-												<option value="devsecops">DevSecOps</option>
-												<option value="other">Other / General Enquiry</option>
-											</select>
-										</div>
-										<div class="field">
-											<label for="message">Message</label>
-											<textarea name="message" id="message" rows="6" placeholder="Tell us a little about what you are working on or what you need help with..."></textarea>
-										</div>
-									</div>
-									<ul class="actions">
-										<li><input type="submit" value="Send Message" class="button primary" /></li>
-									</ul>
-								</form>
-							</div>
+          <!-- Certification Chips -->
+          <article
+            class="bg-surface-container border border-outline-variant border-dashed rounded-xl p-md"
+          >
+            <p
+              class="font-label-sm text-label-sm text-outline mb-md uppercase tracking-widest text-center"
+            >
+              Security &amp; Industry Standards
+            </p>
+            <div class="flex flex-wrap justify-center gap-sm">
+              <span
+                class="px-md py-xs bg-surface-container-highest text-primary-fixed-dim border border-primary-fixed-dim/20 rounded-full font-label-md"
+                >PCI DSS</span
+              >
+              <span
+                class="px-md py-xs bg-surface-container-highest text-primary-fixed-dim border border-primary-fixed-dim/20 rounded-full font-label-md"
+                >Security+</span
+              >
+              <span
+                class="px-md py-xs bg-surface-container-highest text-primary-fixed-dim border border-primary-fixed-dim/20 rounded-full font-label-md"
+                >CREST CPSA</span
+              >
+              <span
+                class="px-md py-xs bg-surface-container-highest text-primary-fixed-dim border border-primary-fixed-dim/20 rounded-full font-label-md"
+                >ISTQB</span
+              >
+            </div>
+          </article>
+        </div>
+      </div>
 
-							<!-- Contact info -->
-							<div class="contact-info-col">
-								<h4>Our Location</h4>
-								<p>
-									Leigh Services<br />
-									63 Archer Avenue<br />
-									Southend on Sea<br />
-									Essex SS2 4QU<br />
-									United Kingdom
-								</p>
+      <!-- Atmospheric Operational Reach Map Section -->
+      <section
+        class="mt-xl rounded-xl overflow-hidden relative h-96 border border-outline-variant"
+      >
+        <iframe
+          src="https://maps.google.com/maps?q=Leigh+IT+Services+Limited,+63+Archer+Avenue,+Southend-on-Sea,+Essex+SS2+4QU&output=embed"
+          class="absolute inset-0 w-full h-full"
+          style="border: 0"
+          loading="lazy"
+          referrerpolicy="no-referrer-when-downgrade"
+          title="Leigh IT Services Limited location map"
+          allowfullscreen
+        ></iframe>
+        <div
+          class="absolute inset-0 bg-gradient-to-t from-background via-transparent to-transparent z-10 pointer-events-none"
+        ></div>
+        <div
+          class="absolute bottom-lg left-lg z-20 bg-surface-container-lowest/80 backdrop-blur-md p-lg rounded-xl border border-outline-variant max-w-md"
+        >
+          <h4 class="font-title-md text-title-md text-primary-fixed-dim mb-sm">
+            Essex, United Kingdom
+          </h4>
+          <p class="font-body-sm text-body-sm text-on-surface-variant">
+            Operational base for nationwide and remote engagements.
+          </p>
+        </div>
+      </section>
+    </main>
 
-								<h4>Connect</h4>
-								<ul>
-									<li><a href="https://www.linkedin.com/in/lukeleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>Luke on LinkedIn</a></li>
-									<li><a href="https://www.linkedin.com/in/markleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>Mark on LinkedIn</a></li>
-									<li><a href="https://github.com/BanterBoy" target="_blank" rel="noopener noreferrer"><i class="icon fa-github">&nbsp;</i>GitHub (BanterBoy)</a></li>
-									<li><a href="https://blog.lukeleigh.com" target="_blank" rel="noopener noreferrer"><i class="icon fa-rss">&nbsp;</i>Luke's Blog</a></li>
-								</ul>
-							</div>
-
-						</div>
-
-					<!-- Map -->
-					<div class="map-wrap">
-						<iframe
-							src="https://maps.google.com/maps?q=Leigh+IT+Services+Limited,+63+Archer+Avenue,+Southend-on-Sea,+Essex+SS2+4QU&output=embed"
-							loading="lazy"
-							referrerpolicy="no-referrer-when-downgrade"
-							title="Leigh IT Services Limited location map"
-							allowfullscreen=""
-						></iframe>
-					</div>
-
-				</div>
-			</div>
-		</section>
-
-		<!-- Footer -->
-			<footer id="footer">
-				<div class="inner">
-					<div class="content">
-						<section>
-							<h3>Leigh Services</h3>
-							<p>Expert IT Infrastructure, Automation and Data Engineering consulting based in Southend-on-Sea, Essex. Serving clients across the UK and internationally.</p>
-							<p>63 Archer Avenue, Southend on Sea, Essex SS2 4QU</p>
-						</section>
-						<section>
-							<h4>Services</h4>
-							<ul class="alt">
-								<li><a href="services.html#it-infrastructure">IT Infrastructure</a></li>
-								<li><a href="services.html#powershell-automation">PowerShell &amp; Automation</a></li>
-								<li><a href="services.html#cloud-solutions">Cloud Solutions</a></li>
-								<li><a href="services.html#data-engineering">Data Engineering</a></li>
-								<li><a href="services.html#security-compliance">Security &amp; Compliance</a></li>
-								<li><a href="services.html#devsecops">DevSecOps</a></li>
-							</ul>
-						</section>
-						<section>
-							<h4>Connect</h4>
-							<ul class="plain">
-								<li><a href="https://www.linkedin.com/in/lukeleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>Luke on LinkedIn</a></li>
-								<li><a href="https://www.linkedin.com/in/markleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>Mark on LinkedIn</a></li>
-								<li><a href="https://github.com/BanterBoy" target="_blank" rel="noopener noreferrer"><i class="icon fa-github">&nbsp;</i>GitHub (BanterBoy)</a></li>
-								<li><a href="https://blog.lukeleigh.com" target="_blank" rel="noopener noreferrer"><i class="icon fa-rss">&nbsp;</i>Luke's Blog</a></li>
-							</ul>
-						</section>
-					</div>
-					<div class="copyright">
-						&copy; 2024&ndash;2026 Leigh IT Services Ltd. All rights reserved.
-					</div>
-				</div>
-			</footer>
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
-
-	</body>
+    <!-- Footer -->
+    <footer class="bg-surface-container-lowest border-t border-outline-variant">
+      <div
+        class="grid grid-cols-1 md:grid-cols-4 gap-xl px-lg py-xl max-w-7xl mx-auto"
+      >
+        <div class="col-span-1 md:col-span-1">
+          <div
+            class="font-title-md text-title-md font-bold text-primary-fixed-dim mb-md"
+          >
+            Leigh Services
+          </div>
+          <p
+            class="font-body-sm text-body-sm text-on-surface-variant leading-relaxed"
+          >
+            Expert IT Infrastructure, Automation and Data Engineering consulting
+            based in Southend-on-Sea, Essex. Serving clients across the UK and
+            internationally.
+          </p>
+          <p
+            class="font-body-sm text-body-sm text-on-surface-variant mt-md italic"
+          >
+            63 Archer Avenue, Southend on Sea, Essex SS2 4QU
+          </p>
+        </div>
+        <div>
+          <div
+            class="font-label-md text-label-md text-primary-fixed-dim mb-md uppercase tracking-wider"
+          >
+            Services
+          </div>
+          <div class="flex flex-col gap-sm">
+            <a
+              class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+              href="services.html#it-infrastructure"
+              >IT Infrastructure</a
+            >
+            <a
+              class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+              href="services.html#powershell-automation"
+              >PowerShell &amp; Automation</a
+            >
+            <a
+              class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+              href="services.html#cloud-solutions"
+              >Cloud Solutions</a
+            >
+            <a
+              class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+              href="services.html#devsecops"
+              >DevSecOps</a
+            >
+          </div>
+        </div>
+        <div>
+          <div
+            class="font-label-md text-label-md text-primary-fixed-dim mb-md uppercase tracking-wider"
+          >
+            Connect
+          </div>
+          <div class="flex flex-col gap-sm">
+            <a
+              class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors inline-flex items-center gap-xs"
+              href="https://www.linkedin.com/in/lukeleigh"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="material-symbols-outlined text-sm">link</span> Luke
+              on LinkedIn
+            </a>
+            <a
+              class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors inline-flex items-center gap-xs"
+              href="https://www.linkedin.com/in/markleigh"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="material-symbols-outlined text-sm">link</span> Mark
+              on LinkedIn
+            </a>
+            <a
+              class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors inline-flex items-center gap-xs"
+              href="https://github.com/BanterBoy"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="material-symbols-outlined text-sm">code</span> GitHub
+              (BanterBoy)
+            </a>
+            <a
+              class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors inline-flex items-center gap-xs"
+              href="https://blog.lukeleigh.com"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="material-symbols-outlined text-sm">rss_feed</span>
+              Luke's Blog
+            </a>
+          </div>
+        </div>
+        <div>
+          <div
+            class="font-label-md text-label-md text-primary-fixed-dim mb-md uppercase tracking-wider"
+          >
+            Legal
+          </div>
+          <p class="font-body-sm text-body-sm text-on-surface-variant mb-md">
+            © 2024-2026 Leigh IT Services Ltd. All rights reserved.
+          </p>
+          <div class="flex gap-md">
+            <span class="material-symbols-outlined text-outline-variant"
+              >verified_user</span
+            >
+            <span class="material-symbols-outlined text-outline-variant"
+              >shield</span
+            >
+          </div>
+        </div>
+      </div>
+    </footer>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,407 +1,963 @@
-<!DOCTYPE HTML>
-<html lang="en-gb">
-	<head>
-		<title>Leigh Services | IT Infrastructure &amp; Data Engineering</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<meta name="description" content="Leigh Services — Expert IT Infrastructure, PowerShell Automation, Data Engineering and Security &amp; Compliance consulting based in Essex, UK." />
-		<meta name="keywords" content="IT infrastructure, PowerShell automation, data engineering, cloud, security, compliance, PCI DSS, Essex, UK" />
-		<meta http-equiv="content-language" content="en-gb" />
-		<link rel="canonical" href="https://leigh-services.com/" />
-		<meta property="og:type" content="website" />
-		<meta property="og:site_name" content="Leigh Services" />
-		<meta property="og:title" content="Leigh Services | IT Infrastructure &amp; Data Engineering" />
-		<meta property="og:description" content="Expert IT Infrastructure, PowerShell Automation, Data Engineering and Security &amp; Compliance consulting based in Essex, UK." />
-		<meta property="og:url" content="https://leigh-services.com/" />
-		<meta property="og:image" content="https://leigh-services.com/images/banner.jpg" />
-		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Leigh Services | IT Infrastructure &amp; Data Engineering" />
-		<meta name="twitter:description" content="Expert IT Infrastructure, PowerShell Automation, Data Engineering and Security &amp; Compliance consulting based in Essex, UK." />
-		<meta name="twitter:image" content="https://leigh-services.com/images/banner.jpg" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<style>
-			/* Team cards */
-			.team-grid {
-				display: -ms-flexbox;
-				display: flex;
-				-ms-flex-wrap: wrap;
-				flex-wrap: wrap;
-				gap: 2em;
-				-ms-flex-pack: center;
-				justify-content: center;
-				margin-top: 2em;
-			}
-			.team-card {
-				background: #f6f6f6;
-				border: 1px solid #e4e4e4;
-				border-radius: 4px;
-				padding: 2.5em 2em;
-				-ms-flex: 1 1 400px;
-				flex: 1 1 400px;
-				max-width: 520px;
-			}
-			.team-card h3 {
-				margin: 0 0 0.2em 0;
-				font-size: 1.4em;
-			}
-			.team-card .tc-role {
-				color: #ce1b28;
-				font-size: 0.8em;
-				font-weight: 700;
-				text-transform: uppercase;
-				letter-spacing: 0.12em;
-				margin: 0 0 1em 0;
-			}
-			.team-card p {
-				font-size: 0.95em;
-				line-height: 1.7;
-				color: #555;
-			}
-			.team-card .tc-skills {
-				display: -ms-flexbox;
-				display: flex;
-				-ms-flex-wrap: wrap;
-				flex-wrap: wrap;
-				gap: 0.4em;
-				margin-top: 1.2em;
-			}
-			.team-card .tc-skill {
-				background: #111;
-				color: #fff;
-				font-size: 0.72em;
-				font-weight: 600;
-				letter-spacing: 0.05em;
-				padding: 0.3em 0.8em;
-				border-radius: 2px;
-			}
-			.team-card .tc-links {
-				margin-top: 1.4em;
-			}
-			.team-card .tc-links a {
-				color: #ce1b28;
-				font-size: 0.88em;
-				margin-right: 1em;
-				text-decoration: none;
-				font-weight: 600;
-			}
-			.team-card .tc-links a:hover {
-				text-decoration: underline;
-			}
-			/* Photo wrapper — 4:3 aspect ratio, image centred */
-			.tc-photo {
-				position: relative;
-				width: 100%;
-				padding-top: 75%; /* 4:3 */
-				border-radius: 4px;
-				overflow: hidden;
-				margin-bottom: 1.4em;
-			}
-			.tc-photo img {
-				position: absolute;
-				top: 0; left: 0;
-				width: 100%;
-				height: 100%;
-				object-fit: cover;
-				object-position: center top;
-				display: block;
-			}
-		</style>
-		<script src="assets/js/metrics.js"></script>
-		<script type="application/ld+json">
-		{
-			"@context": "https://schema.org",
-			"@type": "ProfessionalService",
-			"name": "Leigh Services",
-			"url": "https://leigh-services.com/",
-			"description": "Expert IT Infrastructure, PowerShell Automation, Data Engineering and Security & Compliance consulting based in Essex, UK.",
-			"address": {
-				"@type": "PostalAddress",
-				"streetAddress": "63 Archer Avenue",
-				"addressLocality": "Southend on Sea",
-				"addressRegion": "Essex",
-				"postalCode": "SS2 4QU",
-				"addressCountry": "GB"
-			},
-			"areaServed": "GB",
-			"serviceType": ["IT Infrastructure", "PowerShell Automation", "Data Engineering", "Security Compliance", "DevSecOps"]
-		}
-		</script>
-	</head>
-	<body class="is-preload">
-		<!-- Google Tag Manager (noscript) -->
-		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-		<!-- End Google Tag Manager (noscript) -->
+﻿<!doctype html>
 
-		<!-- Header -->
-			<header id="header">
-				<a class="logo" href="index.html">Leigh Services</a>
-				<nav>
-					<a href="#menu">Menu</a>
-				</nav>
-			</header>
+<html class="dark" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>
+      Leigh Services | Expert IT Infrastructure &amp; Data Engineering
+    </title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@500&amp;display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
+      rel="stylesheet"
+    />
+    <script id="tailwind-config">
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            colors: {
+              "surface-container-low": "#131c2b",
+              "outline-variant": "#3b494c",
+              "on-error": "#690005",
+              "on-tertiary-fixed": "#001945",
+              "surface-container-lowest": "#060e1d",
+              "on-background": "#dbe2f8",
+              "error-container": "#93000a",
+              "on-secondary": "#1b247f",
+              "surface-tint": "#00daf3",
+              "tertiary-container": "#bfd0ff",
+              "primary-container": "#00e5ff",
+              "on-tertiary-fixed-variant": "#00429c",
+              "on-secondary-fixed-variant": "#343d96",
+              "inverse-surface": "#dbe2f8",
+              "inverse-primary": "#006875",
+              "surface-container": "#18202f",
+              surface: "#0b1323",
+              "on-primary-container": "#00626e",
+              "on-primary-fixed": "#001f24",
+              error: "#ffb4ab",
+              "surface-container-high": "#222a3a",
+              "secondary-fixed": "#e0e0ff",
+              "on-secondary-container": "#a8afff",
+              "tertiary-fixed-dim": "#b0c6ff",
+              "secondary-container": "#343d96",
+              "primary-fixed-dim": "#00daf3",
+              tertiary: "#e8ecff",
+              "on-tertiary-container": "#2455af",
+              "on-primary-fixed-variant": "#004f58",
+              "on-secondary-fixed": "#000767",
+              primary: "#c3f5ff",
+              background: "#0b1323",
+              "on-tertiary": "#002d6f",
+              "on-primary": "#00363d",
+              "on-error-container": "#ffdad6",
+              "inverse-on-surface": "#283041",
+              "surface-variant": "#2d3546",
+              "surface-container-highest": "#2d3546",
+              secondary: "#bdc2ff",
+              outline: "#849396",
+              "on-surface-variant": "#bac9cc",
+              "surface-bright": "#31394a",
+              "primary-fixed": "#9cf0ff",
+              "tertiary-fixed": "#d9e2ff",
+              "surface-dim": "#0b1323",
+              "on-surface": "#dbe2f8",
+              "secondary-fixed-dim": "#bdc2ff",
+            },
+            borderRadius: {
+              DEFAULT: "0.125rem",
+              lg: "0.25rem",
+              xl: "0.5rem",
+              full: "0.75rem",
+            },
+            spacing: {
+              xs: "4px",
+              margin: "24px",
+              lg: "24px",
+              xl: "40px",
+              gutter: "16px",
+              base: "4px",
+              sm: "8px",
+              md: "16px",
+            },
+            fontFamily: {
+              "headline-lg-mobile": ["Geist"],
+              "title-md": ["Geist"],
+              "label-sm": ["JetBrains Mono"],
+              "headline-lg": ["Geist"],
+              "body-sm": ["Geist"],
+              "label-md": ["JetBrains Mono"],
+              "body-lg": ["Geist"],
+              "display-lg": ["Geist"],
+            },
+            fontSize: {
+              "headline-lg-mobile": [
+                "24px",
+                { lineHeight: "32px", fontWeight: "600" },
+              ],
+              "title-md": ["20px", { lineHeight: "28px", fontWeight: "500" }],
+              "label-sm": [
+                "10px",
+                {
+                  lineHeight: "14px",
+                  letterSpacing: "0.05em",
+                  fontWeight: "500",
+                },
+              ],
+              "headline-lg": [
+                "32px",
+                { lineHeight: "40px", fontWeight: "600" },
+              ],
+              "body-sm": ["14px", { lineHeight: "20px", fontWeight: "400" }],
+              "label-md": [
+                "12px",
+                {
+                  lineHeight: "16px",
+                  letterSpacing: "0.05em",
+                  fontWeight: "500",
+                },
+              ],
+              "body-lg": ["16px", { lineHeight: "24px", fontWeight: "400" }],
+              "display-lg": [
+                "48px",
+                {
+                  lineHeight: "56px",
+                  letterSpacing: "-0.02em",
+                  fontWeight: "700",
+                },
+              ],
+            },
+          },
+        },
+      };
+    </script>
+    <style>
+      body {
+        background-color: #0b1323;
+        color: #dbe2f8;
+        font-family: "Geist", sans-serif;
+      }
+      .material-symbols-outlined {
+        font-variation-settings:
+          "FILL" 0,
+          "wght" 400,
+          "GRAD" 0,
+          "opsz" 24;
+      }
+      .glass-panel {
+        background: rgba(13, 71, 161, 0.1);
+        backdrop-filter: blur(8px);
+        border: 1px solid rgba(0, 229, 255, 0.1);
+      }
+      .service-card:hover {
+        border-color: #00e5ff;
+        box-shadow: 0 0 20px rgba(0, 229, 255, 0.15);
+      }
+      .active-nav-indicator {
+        position: relative;
+      }
+      .active-nav-indicator::after {
+        content: "";
+        position: absolute;
+        bottom: -4px;
+        left: 0;
+        width: 100%;
+        height: 2px;
+        background-color: #00daf3;
+      }
+    </style>
+  </head>
+  <body class="overflow-x-hidden">
+    <!-- TopNavBar -->
+    <header
+      class="fixed top-0 z-50 w-full bg-surface-container-lowest border-b border-outline-variant"
+    >
+      <nav
+        class="flex justify-between items-center px-lg py-md w-full max-w-7xl mx-auto h-20"
+      >
+        <div
+          class="font-headline-lg text-headline-lg font-bold text-primary-fixed-dim tracking-tight"
+        >
+          Leigh Services
+        </div>
+        <div class="hidden md:flex gap-md items-center">
+          <a
+            class="text-primary-fixed-dim font-bold border-b-2 border-primary-fixed-dim pb-1 font-body-sm text-body-sm hover:text-primary transition-colors duration-200"
+            href="index.html"
+            >Home</a
+          >
+          <a
+            class="text-on-surface-variant font-medium font-body-sm text-body-sm hover:text-primary transition-colors duration-200"
+            href="services.html"
+            >Services</a
+          >
+          <a
+            class="text-on-surface-variant font-medium font-body-sm text-body-sm hover:text-primary transition-colors duration-200"
+            href="team.html"
+            >Meet the Team</a
+          >
+          <a
+            class="text-on-surface-variant font-medium font-body-sm text-body-sm hover:text-primary transition-colors duration-200"
+            href="certifications.html"
+            >Certifications</a
+          >
+          <a
+            class="text-on-surface-variant font-medium font-body-sm text-body-sm hover:text-primary transition-colors duration-200"
+            href="case-studies.html"
+            >Case Studies</a
+          >
+          <a
+            class="text-on-surface-variant font-medium font-body-sm text-body-sm hover:text-primary transition-colors duration-200"
+            href="testimonials.html"
+            >Testimonials</a
+          >
+          <a
+            class="text-on-surface-variant font-medium font-body-sm text-body-sm hover:text-primary transition-colors duration-200"
+            href="blog.html"
+            >Blog</a
+          >
+          <a
+            class="text-on-surface-variant font-medium font-body-sm text-body-sm hover:text-primary transition-colors duration-200"
+            href="contact.html"
+            >Contact</a
+          >
+          <a
+            class="ml-4 px-md py-sm bg-primary-container text-on-primary-container font-bold rounded-lg hover:opacity-80 transition-all"
+            href="contact.html"
+            >Consultation</a
+          >
+        </div>
+        <button
+          class="md:hidden text-on-surface"
+          onclick="
+            document.getElementById('mobile-menu').classList.toggle('hidden')
+          "
+          aria-label="Open menu"
+        >
+          <span class="material-symbols-outlined">menu</span>
+        </button>
+      </nav>
+    </header>
 
-		<!-- Nav -->
-			<nav id="menu">
-				<ul class="links">
-					<li><a href="index.html">Home</a></li>
-					<li><a href="services.html">Services</a></li>
-					<li><a href="team.html">Meet the Team</a></li>
-					<li><a href="certifications.html">Certifications</a></li>
-					<li><a href="case-studies.html">Case Studies</a></li>
-					<li><a href="testimonials.html">Testimonials</a></li>
-					<li><a href="blog.html">Blog</a></li>
-					<li><a href="contact.html">Contact</a></li>
-				</ul>
-			</nav>
-
-		<!-- Banner -->
-			<section id="banner">
-				<div class="inner">
-					<h1>Leigh Services</h1>
-					<p>Expert IT Infrastructure, PowerShell Automation,<br />
-					Data Engineering &amp; Security Consulting.</p>
-				<a href="contact.html" class="button primary fit small">Get in Touch</a>
-				</div>
-				<video autoplay loop muted playsinline src="images/banner.mp4"></video>
-			</section>
-
-		<!-- Services Highlights -->
-			<section class="wrapper">
-				<div class="inner">
-					<header class="special">
-						<h2>What We Do</h2>
-						<p>Leigh Services brings together deep expertise across infrastructure engineering, automation, data platforms and security compliance — delivering reliable, well-engineered solutions for organisations of all sizes.</p>
-					</header>
-					<div class="highlights">
-						<section>
-							<div class="content">
-								<header>
-									<a href="services.html#it-infrastructure" class="icon fa-server"><span class="label">IT Infrastructure</span></a>
-									<h3>IT Infrastructure</h3>
-								</header>
-								<p>End-to-end infrastructure design, implementation and support. From server management and virtualisation to Microsoft 365 and Azure deployments — we keep your systems running reliably and securely.</p>
-							</div>
-						</section>
-						<section>
-							<div class="content">
-								<header>
-									<a href="services.html#powershell-automation" class="icon fa-cogs"><span class="label">PowerShell &amp; Automation</span></a>
-									<h3>PowerShell &amp; Automation</h3>
-								</header>
-								<p>Specialist PowerShell development for infrastructure automation, toolmaking and DevOps workflows. From custom modules to scheduled jobs, we remove manual effort and enforce consistency at scale.</p>
-							</div>
-						</section>
-						<section>
-							<div class="content">
-								<header>
-									<a href="services.html#cloud-solutions" class="icon fa-cloud"><span class="label">Cloud Solutions</span></a>
-									<h3>Cloud Solutions</h3>
-								</header>
-								<p>Cloud architecture and migration across Microsoft Azure and Google Cloud Platform. Licensing, identity, storage, networking and SaaS integration — designed for security and cost-efficiency.</p>
-							</div>
-						</section>
-						<section>
-							<div class="content">
-								<header>
-									<a href="services.html#data-engineering" class="icon fa-database"><span class="label">Data Engineering</span></a>
-									<h3>Data Engineering</h3>
-								</header>
-								<p>Building and stabilising data pipelines and improving integrity and reliability. From legacy SAS migrations to modern cloud data lakes, we make your data accurate, complete and trustworthy.</p>
-							</div>
-						</section>
-						<section>
-							<div class="content">
-								<header>
-									<a href="services.html#security-compliance" class="icon fa-shield"><span class="label">Security &amp; Compliance</span></a>
-									<h3>Security &amp; Compliance</h3>
-								</header>
-								<p>PCI DSS compliance, security hardening, Active Directory governance and audit-ready frameworks. Practical security delivered by engineers who have achieved compliance on real-world complex infrastructures.</p>
-							</div>
-						</section>
-						<section>
-							<div class="content">
-								<header>
-									<a href="services.html#devsecops" class="icon fa-lock"><span class="label">DevSecOps</span></a>
-									<h3>DevSecOps</h3>
-								</header>
-								<p>Integrating security into platforms from the ground up. Pipeline hardening, vulnerability management, SIEM analysis and risk reduction built into your development and operational processes.</p>
-							</div>
-						</section>
-					</div>
-				</div>
-			</section>
-
-		<!-- Testimonials -->
-			<section class="wrapper">
-				<div class="inner">
-					<header class="special">
-						<h2>What Our Clients Say</h2>
-						<p>Recommendations from colleagues and clients across IT infrastructure, data engineering and compliance projects.</p>
-					</header>
-					<div class="testimonials">
-
-						<div>
-							<div class="content">
-								<div class="author">
-									<blockquote>
-										<p>"I had the pleasure of working with Luke delivering a PCI compliance project for an organisation up against a tight time deadline. Luke was extremely knowledgeable and easy to get on with. His PowerShell scripting offered up innovative solutions. His ideas were pragmatic and based on actual real IT experience which is rare these days."</p>
-									</blockquote>
-								</div>
-								<p class="credit">
-									<strong>Ron Williams</strong><br />
-									Chief Executive &middot; PCI DSS QSA &amp; Cyber Security Professional
-								</p>
-							</div>
-						</div>
-
-						<div>
-							<div class="content">
-								<div class="author">
-									<blockquote>
-										<p>"I have worked together with Mark on several projects as part of the Data Engineering team at Swarovski. Mark is a real team player and an experienced project leader who is able to provide guidance and manage multi-stakeholder environments. He is very versatile and able to master new technologies rapidly."</p>
-									</blockquote>
-								</div>
-								<p class="credit">
-									<strong>Martin I.</strong><br />
-									Data Science &amp; Data Engineering &middot; Swarovski
-								</p>
-							</div>
-						</div>
-
-						<div>
-							<div class="content">
-								<div class="author">
-									<blockquote>
-										<p>"I worked with Mark on a complex financial reporting project. His attention to detail is second to none. He was open to suggestions, able to follow ideas through and clearly explain why something would or wouldn't work. He was supportive of test and would point me in a new direction if new development warranted it."</p>
-									</blockquote>
-								</div>
-								<p class="credit">
-									<strong>Gary Burgess (DipAF)</strong><br />
-									ISTQB Certified Tester Foundation
-								</p>
-							</div>
-						</div>
-
-					</div>
-					<div style="text-align:center; margin-top:2em;">
-						<a href="testimonials.html" class="button">Read All Recommendations</a>
-					</div>
-				</div>
-			</section>
-
-		<!-- CTA -->
-			<section id="cta" class="wrapper">
-				<div class="inner">
-					<h2>Ready to work together?</h2>
-					<p>Whether you need infrastructure support, automation tooling, data platform engineering or compliance guidance — we bring the expertise to get the job done. Get in touch and let's talk about what we can do for you.</p>
-				<a href="contact.html" class="button fit small">Get in Touch</a>
-				</div>
-			</section>
-
-		<!-- Meet the Owners -->
-			<section class="wrapper">
-				<div class="inner">
-					<header class="special">
-						<h2>Meet the Owners</h2>
-						<p>Leigh Services is built on the combined experience of two seasoned engineers — Luke Leigh and Mark Leigh — with over 50 years of industry expertise between them.</p>
-					</header>
-					<div class="team-grid">
-
-						<div class="team-card">
-							<div class="tc-photo">
-								<img src="images/lukeleigh.jpg" alt="Luke Leigh" />
-							</div>
-							<h3>Luke Leigh</h3>
-							<p class="tc-role">Infrastructure Engineer &amp; Owner</p>
-							<p>A dependable and analytical Infrastructure Engineer with deep expertise in IT infrastructure, PowerShell development and automation. Currently serving as Infrastructure Engineer at Rail Delivery Group, Luke's primary focus is on-premises to Microsoft 365 migrations, system management and PowerShell automation — delivering reliable, well-engineered solutions across a wide range of industries over 25+ years.</p>
-							<div class="tc-skills">
-								<span class="tc-skill">PowerShell</span>
-								<span class="tc-skill">Automation</span>
-								<span class="tc-skill">Incident Management</span>
-								<span class="tc-skill">Azure / M365</span>
-								<span class="tc-skill">VMware</span>
-								<span class="tc-skill">On-prem / O365 Migration</span>
-								<span class="tc-skill">PCI DSS</span>
-								<span class="tc-skill">Exchange Online</span>
-							</div>
-							<div class="tc-links">
-								<a href="https://www.linkedin.com/in/lukeleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>LinkedIn</a>
-								<a href="https://github.com/BanterBoy" target="_blank" rel="noopener noreferrer"><i class="icon fa-github">&nbsp;</i>GitHub</a>
-								<a href="https://blog.lukeleigh.com" target="_blank" rel="noopener noreferrer"><i class="icon fa-rss">&nbsp;</i>Blog</a>
-							</div>
-						</div>
-
-						<div class="team-card">
-							<div class="tc-photo">
-								<img src="images/markleigh.jpg" alt="Mark Leigh" />
-							</div>
-							<h3>Mark Leigh</h3>
-							<p class="tc-role">Senior Data Engineer &amp; Security Specialist</p>
-							<p>A senior data engineer focused on improving the integrity, reliability and security of data platforms. CompTIA Security+ certified with CREST CPSA ongoing, Mark brings a DevSecOps mindset to data engineering — building platforms with security, control and risk management considered from the outset. His work at Swarovski led a legacy SAS-to-GCP migration delivering &euro;1m in annual cost savings. He has also delivered regulatory reporting solutions in complex banking environments including Lloyds Banking Group.</p>
-							<div class="tc-skills">
-								<span class="tc-skill">Data Engineering</span>
-								<span class="tc-skill">DevSecOps</span>
-								<span class="tc-skill">Python</span>
-								<span class="tc-skill">SQL</span>
-								<span class="tc-skill">SAS</span>
-								<span class="tc-skill">Google Cloud (GCP)</span>
-								<span class="tc-skill">CompTIA Security+</span>
-								<span class="tc-skill">CREST CPSA</span>
-							</div>
-							<div class="tc-links">
-								<a href="https://www.linkedin.com/in/markleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>LinkedIn</a>
-							</div>
-						</div>
-
-					</div>
-					<div style="text-align:center; margin-top:2.5em;">
-					<a href="team.html" class="button">Full Team Profiles</a>
-					</div>
-				</div>
-			</section>
-
-		<!-- Footer -->
-			<footer id="footer">
-				<div class="inner">
-					<div class="content">
-						<section>
-							<h3>Leigh Services</h3>
-							<p>Expert IT Infrastructure, Automation and Data Engineering consulting based in Southend-on-Sea, Essex. Serving clients across the UK and internationally.</p>
-						<p>63 Archer Avenue, Southend on Sea, Essex SS2 4QU</p>
-						</section>
-						<section>
-							<h4>Services</h4>
-							<ul class="alt">
-							<li><a href="services.html#it-infrastructure">IT Infrastructure</a></li>
-							<li><a href="services.html#powershell-automation">PowerShell &amp; Automation</a></li>
-							<li><a href="services.html#cloud-solutions">Cloud Solutions</a></li>
-							<li><a href="services.html#data-engineering">Data Engineering</a></li>
-							<li><a href="services.html#security-compliance">Security &amp; Compliance</a></li>
-							<li><a href="services.html#devsecops">DevSecOps</a></li>
-							</ul>
-						</section>
-						<section>
-							<h4>Connect</h4>
-							<ul class="plain">
-								<li><a href="https://www.linkedin.com/in/lukeleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>Luke on LinkedIn</a></li>
-								<li><a href="https://www.linkedin.com/in/markleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>Mark on LinkedIn</a></li>
-								<li><a href="https://github.com/BanterBoy" target="_blank" rel="noopener noreferrer"><i class="icon fa-github">&nbsp;</i>GitHub (BanterBoy)</a></li>
-								<li><a href="https://blog.lukeleigh.com" target="_blank" rel="noopener noreferrer"><i class="icon fa-rss">&nbsp;</i>Luke's Blog</a></li>
-							</ul>
-						</section>
-					</div>
-					<div class="copyright">
-					&copy; 2024&ndash;2026 Leigh IT Services Ltd. All rights reserved.
-					</div>
-				</div>
-			</footer>
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
-
-	</body>
+    <!-- Mobile Menu -->
+    <div
+      class="hidden md:hidden fixed inset-0 z-[110] bg-surface-container-lowest p-lg"
+      id="mobile-menu"
+    >
+      <div class="flex flex-col gap-md">
+        <div class="flex justify-between items-center mb-xl">
+          <span
+            class="font-headline-lg-mobile text-headline-lg-mobile text-primary-fixed-dim"
+            >Leigh Services</span
+          >
+          <button
+            onclick="
+              document.getElementById('mobile-menu').classList.add('hidden')
+            "
+            aria-label="Close menu"
+          >
+            <span class="material-symbols-outlined">close</span>
+          </button>
+        </div>
+        <a
+          class="text-title-md py-sm text-primary-fixed-dim font-bold"
+          href="index.html"
+          >Home</a
+        >
+        <a class="text-title-md py-sm" href="services.html">Services</a>
+        <a class="text-title-md py-sm" href="team.html">Meet the Team</a>
+        <a class="text-title-md py-sm" href="certifications.html"
+          >Certifications</a
+        >
+        <a class="text-title-md py-sm" href="case-studies.html">Case Studies</a>
+        <a class="text-title-md py-sm" href="testimonials.html">Testimonials</a>
+        <a class="text-title-md py-sm" href="blog.html">Blog</a>
+        <a class="text-title-md py-sm" href="contact.html">Contact</a>
+        <a
+          class="mt-md bg-primary-container text-on-primary-container text-center px-md py-md rounded-lg font-bold"
+          href="contact.html"
+          >Consultation</a
+        >
+      </div>
+    </div>
+    <main class="pt-20">
+      <!-- Hero Section -->
+      <section class="relative min-h-[80vh] flex items-center overflow-hidden">
+        <div
+          class="relative z-10 max-w-7xl mx-auto px-lg grid md:grid-cols-2 gap-xl items-center"
+        >
+          <div class="space-y-md">
+            <div
+              class="inline-flex items-center gap-sm px-sm py-xs bg-secondary-container/30 border border-outline-variant rounded-full"
+            >
+              <span
+                class="w-2 h-2 rounded-full bg-primary-container animate-pulse"
+              ></span>
+              <span class="font-label-md text-label-md text-primary-fixed-dim"
+                >Infrastructure Experts</span
+              >
+            </div>
+            <h1 class="font-display-lg text-display-lg leading-tight">
+              Expert IT Infrastructure,
+              <span class="text-primary-fixed-dim">PowerShell Automation</span>,
+              Data Engineering &amp; Security Consulting.
+            </h1>
+            <p
+              class="font-body-lg text-body-lg text-on-surface-variant max-w-xl"
+            >
+              Delivering reliable, well-engineered solutions for organisations
+              of all sizes through deep technical expertise.
+            </p>
+            <div class="flex gap-md pt-md">
+              <a
+                class="px-xl py-md bg-primary-container text-on-primary-container font-bold rounded-xl hover:shadow-[0_0_20px_rgba(0,229,255,0.4)] transition-all flex items-center gap-sm"
+                href="contact.html"
+              >
+                Get in Touch
+                <span class="material-symbols-outlined">arrow_forward</span>
+              </a>
+              <a
+                class="px-xl py-md border border-outline text-primary-fixed-dim font-bold rounded-xl hover:bg-surface-container-high transition-all"
+                href="services.html"
+              >
+                Our Services
+              </a>
+            </div>
+          </div>
+          <div class="hidden md:block">
+            <div class="relative group">
+              <div
+                class="absolute -inset-4 bg-primary-container/10 blur-3xl rounded-full group-hover:bg-primary-container/20 transition-all"
+              ></div>
+              <div
+                class="relative glass-panel rounded-xl p-md border-primary-container/30 overflow-hidden aspect-square flex items-center justify-center"
+              >
+                <span
+                  class="material-symbols-outlined text-[120px] text-primary-fixed-dim/40"
+                  style="font-variation-settings: &quot;FILL&quot; 1"
+                  >terminal</span
+                >
+                <div
+                  class="absolute bottom-md left-md right-md bg-surface-container-highest/80 p-sm rounded-lg border border-outline-variant font-label-sm text-label-sm text-primary"
+                >
+                  <span class="text-on-surface">system_status:</span> optimal
+                  <br />
+                  <span class="text-on-surface">automation_tasks:</span> active
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <!-- What We Do Bento Grid -->
+      <section class="py-xl bg-surface-container-lowest">
+        <div class="max-w-7xl mx-auto px-lg">
+          <div class="mb-xl max-w-3xl">
+            <h2 class="font-headline-lg text-headline-lg mb-sm">What We Do</h2>
+            <p class="font-body-lg text-body-lg text-on-surface-variant">
+              Leigh Services brings together deep expertise across
+              infrastructure engineering, automation, data platforms and
+              security compliance — delivering reliable, well-engineered
+              solutions for organisations of all sizes.
+            </p>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-md">
+            <!-- IT Infrastructure -->
+            <div
+              class="md:col-span-2 group glass-panel p-lg rounded-xl service-card transition-all flex flex-col justify-between"
+            >
+              <div>
+                <div
+                  class="w-12 h-12 rounded-lg bg-primary-container/20 flex items-center justify-center mb-md"
+                >
+                  <span class="material-symbols-outlined text-primary-fixed-dim"
+                    >storage</span
+                  >
+                </div>
+                <h3 class="font-title-md text-title-md mb-sm">
+                  IT Infrastructure
+                </h3>
+                <p
+                  class="font-body-sm text-body-sm text-on-surface-variant mb-md"
+                >
+                  End-to-end infrastructure design, implementation and support.
+                  From server management and virtualisation to Microsoft 365 and
+                  Azure deployments — we keep your systems running reliably and
+                  securely.
+                </p>
+              </div>
+              <a
+                class="text-primary-fixed-dim font-label-md flex items-center gap-xs hover:gap-sm transition-all"
+                href="services.html#it-infrastructure"
+              >
+                LEARN MORE
+                <span class="material-symbols-outlined text-sm"
+                  >chevron_right</span
+                >
+              </a>
+            </div>
+            <!-- PowerShell -->
+            <div
+              class="group glass-panel p-lg rounded-xl service-card transition-all flex flex-col"
+            >
+              <div
+                class="w-12 h-12 rounded-lg bg-primary-container/20 flex items-center justify-center mb-md"
+              >
+                <span class="material-symbols-outlined text-primary-fixed-dim"
+                  >code</span
+                >
+              </div>
+              <h3 class="font-title-md text-title-md mb-sm">
+                PowerShell &amp; Automation
+              </h3>
+              <p
+                class="font-body-sm text-body-sm text-on-surface-variant flex-grow"
+              >
+                Specialist PowerShell development for infrastructure automation,
+                toolmaking and DevOps workflows. We remove manual effort and
+                enforce consistency.
+              </p>
+            </div>
+            <!-- Cloud Solutions -->
+            <div
+              class="group glass-panel p-lg rounded-xl service-card transition-all flex flex-col"
+            >
+              <div
+                class="w-12 h-12 rounded-lg bg-primary-container/20 flex items-center justify-center mb-md"
+              >
+                <span class="material-symbols-outlined text-primary-fixed-dim"
+                  >cloud</span
+                >
+              </div>
+              <h3 class="font-title-md text-title-md mb-sm">Cloud Solutions</h3>
+              <p
+                class="font-body-sm text-body-sm text-on-surface-variant flex-grow"
+              >
+                Cloud architecture and migration across Microsoft Azure and
+                Google Cloud Platform. Designed for security and
+                cost-efficiency.
+              </p>
+            </div>
+            <!-- Data Engineering -->
+            <div
+              class="group glass-panel p-lg rounded-xl service-card transition-all flex flex-col"
+            >
+              <div
+                class="w-12 h-12 rounded-lg bg-primary-container/20 flex items-center justify-center mb-md"
+              >
+                <span class="material-symbols-outlined text-primary-fixed-dim"
+                  >database</span
+                >
+              </div>
+              <h3 class="font-title-md text-title-md mb-sm">
+                Data Engineering
+              </h3>
+              <p
+                class="font-body-sm text-body-sm text-on-surface-variant flex-grow"
+              >
+                Building and stabilising data pipelines and improving integrity.
+                From legacy SAS migrations to modern cloud data lakes.
+              </p>
+            </div>
+            <!-- Security & Compliance -->
+            <div
+              class="group glass-panel p-lg rounded-xl service-card transition-all flex flex-col"
+            >
+              <div
+                class="w-12 h-12 rounded-lg bg-primary-container/20 flex items-center justify-center mb-md"
+              >
+                <span class="material-symbols-outlined text-primary-fixed-dim"
+                  >gavel</span
+                >
+              </div>
+              <h3 class="font-title-md text-title-md mb-sm">
+                Security &amp; Compliance
+              </h3>
+              <p
+                class="font-body-sm text-body-sm text-on-surface-variant flex-grow"
+              >
+                PCI DSS compliance, security hardening, and Active Directory
+                governance. Practical security delivered by experienced
+                engineers.
+              </p>
+            </div>
+            <!-- DevSecOps -->
+            <div
+              class="md:col-span-3 group glass-panel p-lg rounded-xl service-card transition-all flex flex-col md:flex-row md:items-center gap-md"
+            >
+              <div
+                class="w-12 h-12 min-w-[3rem] rounded-lg bg-primary-container/20 flex items-center justify-center"
+              >
+                <span class="material-symbols-outlined text-primary-fixed-dim"
+                  >security</span
+                >
+              </div>
+              <div class="flex-grow">
+                <h3 class="font-title-md text-title-md mb-xs">DevSecOps</h3>
+                <p class="font-body-sm text-body-sm text-on-surface-variant">
+                  Integrating security into platforms from the ground up.
+                  Pipeline hardening, vulnerability management, and SIEM
+                  analysis built into your operations.
+                </p>
+              </div>
+              <a
+                class="inline-flex items-center gap-xs px-md py-sm border border-outline-variant rounded-lg hover:bg-surface-container-high"
+                href="services.html#devsecops"
+              >
+                Details
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+      <!-- Testimonials Section -->
+      <section class="py-xl bg-surface">
+        <div class="max-w-7xl mx-auto px-lg">
+          <div class="text-center mb-xl">
+            <h2 class="font-headline-lg text-headline-lg mb-sm">
+              What Our Clients Say
+            </h2>
+            <p
+              class="font-body-lg text-body-lg text-on-surface-variant max-w-2xl mx-auto"
+            >
+              Recommendations from colleagues and clients across IT
+              infrastructure, data engineering and compliance projects.
+            </p>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-lg">
+            <!-- Ron Williams -->
+            <div
+              class="glass-panel p-lg rounded-xl flex flex-col h-full border-l-2 border-l-primary-fixed-dim"
+            >
+              <div class="text-primary-fixed-dim mb-md italic">
+                <span class="material-symbols-outlined align-middle"
+                  >format_quote</span
+                >
+              </div>
+              <p
+                class="font-body-sm text-body-sm text-on-surface mb-md flex-grow"
+              >
+                "I had the pleasure of working with Luke delivering a PCI
+                compliance project for an organisation up against a tight time
+                deadline. Luke was extremely knowledgeable and easy to get on
+                with. His PowerShell scripting offered up innovative solutions.
+                His ideas were pragmatic and based on actual real IT experience
+                which is rare these days."
+              </p>
+              <div class="border-t border-outline-variant pt-md">
+                <p class="font-body-sm font-bold text-on-surface">
+                  Ron Williams
+                </p>
+                <p class="font-label-sm text-on-surface-variant">
+                  Chief Executive * PCI DSS QSA &amp; Cyber Security
+                  Professional
+                </p>
+              </div>
+            </div>
+            <!-- Martin I -->
+            <div
+              class="glass-panel p-lg rounded-xl flex flex-col h-full border-l-2 border-l-primary-fixed-dim"
+            >
+              <div class="text-primary-fixed-dim mb-md italic">
+                <span class="material-symbols-outlined align-middle"
+                  >format_quote</span
+                >
+              </div>
+              <p
+                class="font-body-sm text-body-sm text-on-surface mb-md flex-grow"
+              >
+                "I have worked together with Mark on several projects as part of
+                the Data Engineering team at Swarovski. Mark is a real team
+                player and an experienced project leader who is able to provide
+                guidance and manage multi-stakeholder environments. He is very
+                versatile and able to master new technologies rapidly."
+              </p>
+              <div class="border-t border-outline-variant pt-md">
+                <p class="font-body-sm font-bold text-on-surface">Martin I.</p>
+                <p class="font-label-sm text-on-surface-variant">
+                  Data Science &amp; Data Engineering * Swarovski
+                </p>
+              </div>
+            </div>
+            <!-- Gary Burgess -->
+            <div
+              class="glass-panel p-lg rounded-xl flex flex-col h-full border-l-2 border-l-primary-fixed-dim"
+            >
+              <div class="text-primary-fixed-dim mb-md italic">
+                <span class="material-symbols-outlined align-middle"
+                  >format_quote</span
+                >
+              </div>
+              <p
+                class="font-body-sm text-body-sm text-on-surface mb-md flex-grow"
+              >
+                "I worked with Mark on a complex financial reporting project.
+                His attention to detail is second to none. He was open to
+                suggestions, able to follow ideas through and clearly explain
+                why something would or wouldn't work. He was supportive of test
+                and would point me in a new direction if new development
+                warranted it."
+              </p>
+              <div class="border-t border-outline-variant pt-md">
+                <p class="font-body-sm font-bold text-on-surface">
+                  Gary Burgess (DipAF)
+                </p>
+                <p class="font-label-sm text-on-surface-variant">
+                  ISTQB Certified Tester Foundation
+                </p>
+              </div>
+            </div>
+          </div>
+          <div class="text-center mt-xl">
+            <a
+              class="inline-flex items-center gap-sm px-xl py-md border border-outline text-primary-fixed-dim font-bold rounded-xl hover:bg-surface-container-high transition-all"
+              href="testimonials.html"
+            >
+              Read All Recommendations
+            </a>
+          </div>
+        </div>
+      </section>
+      <!-- CTA Section -->
+      <section class="py-xl">
+        <div class="max-w-7xl mx-auto px-lg">
+          <div
+            class="relative rounded-2xl overflow-hidden bg-surface-container-high p-xl md:p-[80px]"
+          >
+            <div class="absolute inset-0 opacity-10"></div>
+            <div class="relative z-10 max-w-2xl">
+              <h2 class="font-headline-lg text-headline-lg mb-md">
+                Ready to work together?
+              </h2>
+              <p
+                class="font-body-lg text-body-lg text-on-surface-variant mb-xl"
+              >
+                Whether you need infrastructure support, automation tooling,
+                data platform engineering or compliance guidance — we bring the
+                expertise to get the job done.
+              </p>
+              <a
+                class="px-xl py-md bg-primary-container text-on-primary-container font-bold rounded-xl hover:shadow-lg transition-all inline-block"
+                href="contact.html"
+              >
+                Get in Touch
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+      <!-- Meet the Owners Section -->
+      <section class="py-xl bg-surface-container-lowest">
+        <div class="max-w-7xl mx-auto px-lg">
+          <div class="mb-xl text-center md:text-left">
+            <h2 class="font-headline-lg text-headline-lg mb-sm">
+              Meet the Owners
+            </h2>
+            <p
+              class="font-body-lg text-body-lg text-on-surface-variant max-w-3xl"
+            >
+              Leigh Services is built on the combined experience of two seasoned
+              engineers — Luke Leigh and Mark Leigh — with over 50 years of
+              industry expertise between them.
+            </p>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-xl">
+            <!-- Luke Leigh -->
+            <div class="space-y-md">
+              <div class="relative h-[400px] rounded-xl overflow-hidden group">
+                <img
+                  alt="Luke Leigh"
+                  class="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+                  src="images/lukeleigh.jpg"
+                />
+                <div
+                  class="absolute inset-0 bg-gradient-to-t from-background to-transparent opacity-60"
+                ></div>
+              </div>
+              <div>
+                <h3 class="font-headline-lg text-headline-lg">Luke Leigh</h3>
+                <p class="text-primary-fixed-dim font-bold mb-md">
+                  Infrastructure Engineer &amp; Owner
+                </p>
+                <p
+                  class="font-body-sm text-body-sm text-on-surface-variant mb-md"
+                >
+                  A dependable and analytical Infrastructure Engineer with deep
+                  expertise in IT infrastructure, PowerShell development and
+                  automation. Currently serving as Infrastructure Engineer at
+                  Rail Delivery Group, Luke's primary focus is on-premises to
+                  Microsoft 365 migrations, system management and PowerShell
+                  automation — delivering reliable, well-engineered solutions
+                  across a wide range of industries over 25+ years.
+                </p>
+                <div class="flex flex-wrap gap-sm mb-md">
+                  <span
+                    class="px-sm py-xs bg-surface-container-high rounded-lg font-label-sm text-primary"
+                    >PowerShell</span
+                  >
+                  <span
+                    class="px-sm py-xs bg-surface-container-high rounded-lg font-label-sm text-primary"
+                    >Automation</span
+                  >
+                  <span
+                    class="px-sm py-xs bg-surface-container-high rounded-lg font-label-sm text-primary"
+                    >Azure / M365</span
+                  >
+                  <span
+                    class="px-sm py-xs bg-surface-container-high rounded-lg font-label-sm text-primary"
+                    >VMware</span
+                  >
+                  <span
+                    class="px-sm py-xs bg-surface-container-high rounded-lg font-label-sm text-primary"
+                    >PCI DSS</span
+                  >
+                </div>
+                <div class="flex gap-md text-on-surface-variant">
+                  <a
+                    class="hover:text-primary-fixed-dim transition-colors"
+                    href="https://www.linkedin.com/in/lukeleigh"
+                    ><span class="material-symbols-outlined">link</span>
+                    LinkedIn</a
+                  >
+                  <a
+                    class="hover:text-primary-fixed-dim transition-colors"
+                    href="https://github.com/BanterBoy"
+                    ><span class="material-symbols-outlined">terminal</span>
+                    GitHub</a
+                  >
+                  <a
+                    class="hover:text-primary-fixed-dim transition-colors"
+                    href="https://blog.lukeleigh.com"
+                    ><span class="material-symbols-outlined">rss_feed</span>
+                    Blog</a
+                  >
+                </div>
+              </div>
+            </div>
+            <!-- Mark Leigh -->
+            <div class="space-y-md">
+              <div class="relative h-[400px] rounded-xl overflow-hidden group">
+                <img
+                  alt="Mark Leigh"
+                  class="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+                  src="images/markleigh.jpg"
+                />
+                <div
+                  class="absolute inset-0 bg-gradient-to-t from-background to-transparent opacity-60"
+                ></div>
+              </div>
+              <div>
+                <h3 class="font-headline-lg text-headline-lg">Mark Leigh</h3>
+                <p class="text-primary-fixed-dim font-bold mb-md">
+                  Senior Data Engineer &amp; Security Specialist
+                </p>
+                <p
+                  class="font-body-sm text-body-sm text-on-surface-variant mb-md"
+                >
+                  A senior data engineer focused on improving the integrity,
+                  reliability and security of data platforms. CompTIA Security+
+                  certified with CREST CPSA ongoing, Mark brings a DevSecOps
+                  mindset to data engineering — building platforms with
+                  security, control and risk management considered from the
+                  outset. His work at Swarovski led a legacy SAS-to-GCP
+                  migration delivering €1m in annual cost savings.
+                </p>
+                <div class="flex flex-wrap gap-sm mb-md">
+                  <span
+                    class="px-sm py-xs bg-surface-container-high rounded-lg font-label-sm text-primary"
+                    >Data Engineering</span
+                  >
+                  <span
+                    class="px-sm py-xs bg-surface-container-high rounded-lg font-label-sm text-primary"
+                    >DevSecOps</span
+                  >
+                  <span
+                    class="px-sm py-xs bg-surface-container-high rounded-lg font-label-sm text-primary"
+                    >Python</span
+                  >
+                  <span
+                    class="px-sm py-xs bg-surface-container-high rounded-lg font-label-sm text-primary"
+                    >Google Cloud (GCP)</span
+                  >
+                  <span
+                    class="px-sm py-xs bg-surface-container-high rounded-lg font-label-sm text-primary"
+                    >CompTIA Security+</span
+                  >
+                </div>
+                <div class="flex gap-md text-on-surface-variant">
+                  <a
+                    class="hover:text-primary-fixed-dim transition-colors"
+                    href="https://www.linkedin.com/in/markleigh"
+                    ><span class="material-symbols-outlined">link</span>
+                    LinkedIn</a
+                  >
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="mt-xl text-center">
+            <a
+              class="inline-flex items-center gap-sm px-xl py-md border border-outline text-primary-fixed-dim font-bold rounded-xl hover:bg-surface-container-high transition-all"
+              href="team.html"
+            >
+              Full Team Profiles
+            </a>
+          </div>
+        </div>
+      </section>
+    </main>
+    <!-- Footer -->
+    <footer
+      class="bg-surface-container-lowest border-t border-outline-variant py-xl"
+    >
+      <div
+        class="max-w-7xl mx-auto px-lg grid grid-cols-1 md:grid-cols-4 gap-xl"
+      >
+        <div class="space-y-md">
+          <div
+            class="font-title-md text-title-md font-bold text-primary-fixed-dim"
+          >
+            Leigh Services
+          </div>
+          <p class="font-body-sm text-body-sm text-on-surface-variant">
+            Expert IT Infrastructure, Automation and Data Engineering consulting
+            based in Southend-on-Sea, Essex. Serving clients across the UK and
+            internationally.
+          </p>
+          <p class="font-body-sm text-body-sm text-on-surface-variant">
+            63 Archer Avenue, Southend on Sea, Essex SS2 4QU
+          </p>
+        </div>
+        <div class="space-y-md">
+          <div
+            class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-wider"
+          >
+            Services
+          </div>
+          <ul
+            class="space-y-sm font-body-sm text-body-sm text-on-surface-variant"
+          >
+            <li>
+              <a
+                class="hover:text-primary-fixed-dim transition-colors"
+                href="services.html#it-infrastructure"
+                >IT Infrastructure</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary-fixed-dim transition-colors"
+                href="services.html#powershell-automation"
+                >PowerShell &amp; Automation</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary-fixed-dim transition-colors"
+                href="services.html#cloud-solutions"
+                >Cloud Solutions</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary-fixed-dim transition-colors"
+                href="services.html#data-engineering"
+                >Data Engineering</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary-fixed-dim transition-colors"
+                href="services.html#security-compliance"
+                >Security &amp; Compliance</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary-fixed-dim transition-colors"
+                href="services.html#devsecops"
+                >DevSecOps</a
+              >
+            </li>
+          </ul>
+        </div>
+        <div class="space-y-md">
+          <div
+            class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-wider"
+          >
+            Connect
+          </div>
+          <ul
+            class="space-y-sm font-body-sm text-body-sm text-on-surface-variant"
+          >
+            <li>
+              <a
+                class="hover:text-primary-fixed-dim transition-colors flex items-center gap-xs"
+                href="https://www.linkedin.com/in/lukeleigh"
+                >Luke on LinkedIn</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary-fixed-dim transition-colors flex items-center gap-xs"
+                href="https://www.linkedin.com/in/markleigh"
+                >Mark on LinkedIn</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary-fixed-dim transition-colors flex items-center gap-xs"
+                href="https://github.com/BanterBoy"
+                >GitHub (BanterBoy)</a
+              >
+            </li>
+            <li>
+              <a
+                class="hover:text-primary-fixed-dim transition-colors flex items-center gap-xs"
+                href="https://blog.lukeleigh.com"
+                >Luke's Blog</a
+              >
+            </li>
+          </ul>
+        </div>
+        <div class="space-y-md">
+          <div
+            class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-wider"
+          >
+            Legal
+          </div>
+          <p class="font-body-sm text-body-sm text-on-surface-variant">
+            © 2024-2026 Leigh IT Services Ltd. <br />All rights reserved.
+          </p>
+          <div class="flex gap-md pt-sm">
+            <span
+              class="material-symbols-outlined text-outline-variant cursor-help"
+              title="Quality Guaranteed"
+              >verified</span
+            >
+            <span
+              class="material-symbols-outlined text-outline-variant cursor-help"
+              title="Secure Solutions"
+              >lock</span
+            >
+            <span
+              class="material-symbols-outlined text-outline-variant cursor-help"
+              title="Automation Experts"
+              >bolt</span
+            >
+          </div>
+        </div>
+      </div>
+    </footer>
+  </body>
 </html>

--- a/services.html
+++ b/services.html
@@ -1,200 +1,716 @@
-<!DOCTYPE HTML>
-<html lang="en-gb">
-	<head>
-		<title>Services | Leigh Services</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<meta name="description" content="Leigh Services offers IT Infrastructure, PowerShell Automation, Cloud Solutions, Data Engineering, Security &amp; Compliance, and DevSecOps consulting." />
-		<meta name="keywords" content="IT infrastructure, PowerShell automation, cloud solutions, data engineering, security compliance, DevSecOps, Essex, UK" />
-		<meta property="og:title" content="Services | Leigh Services" />
-		<meta property="og:description" content="Expert IT Infrastructure, PowerShell Automation, Cloud Solutions, Data Engineering, Security &amp; Compliance, and DevSecOps consulting." />
-		<meta property="og:url" content="https://leigh-services.com/services.html" />
-		<meta property="og:image" content="https://leigh-services.com/images/banner.jpg" />
-		<meta property="og:type" content="website" />
-		<meta property="og:site_name" content="Leigh Services" />
-		<meta http-equiv="content-language" content="en-gb" />
-		<link rel="canonical" href="https://leigh-services.com/services.html" />
-		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Services | Leigh Services" />
-		<meta name="twitter:description" content="Expert IT Infrastructure, PowerShell Automation, Cloud Solutions, Data Engineering, Security &amp; Compliance, and DevSecOps consulting." />
-		<meta name="twitter:image" content="https://leigh-services.com/images/banner.jpg" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<style>
-			.service-section {
-				padding: 3em 0;
-				border-bottom: 1px solid #e4e4e4;
-			}
-			.service-section:last-of-type {
-				border-bottom: none;
-				padding-bottom: 0;
-			}
-			.service-section .service-icon {
-				font-size: 2.5em;
-				color: #ce1b28;
-				margin-bottom: 0.5em;
-			}
-			.service-section h2 {
-				margin-bottom: 0.5em;
-			}
-			.service-section p {
-				color: #555;
-				line-height: 1.75;
-				margin-bottom: 1em;
-			}
-			.service-cta {
-				margin-top: 1.5em;
-			}
-		</style>
-		<script src="assets/js/metrics.js"></script>
-	</head>
-	<body class="is-preload">
-		<!-- Google Tag Manager (noscript) -->
-		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-		<!-- End Google Tag Manager (noscript) -->
+﻿<!doctype html>
 
-		<!-- Header -->
-			<header id="header">
-				<a class="logo" href="index.html">Leigh Services</a>
-				<nav>
-					<a href="#menu">Menu</a>
-				</nav>
-			</header>
+<html class="dark" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Services | Leigh Services - Expert IT &amp; Data Engineering</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&amp;family=JetBrains+Mono:wght@100..800&amp;display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
+      rel="stylesheet"
+    />
+    <script id="tailwind-config">
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            colors: {
+              "surface-container-low": "#131c2b",
+              "outline-variant": "#3b494c",
+              "on-error": "#690005",
+              "on-tertiary-fixed": "#001945",
+              "surface-container-lowest": "#060e1d",
+              "on-background": "#dbe2f8",
+              "error-container": "#93000a",
+              "on-secondary": "#1b247f",
+              "surface-tint": "#00daf3",
+              "tertiary-container": "#bfd0ff",
+              "primary-container": "#00e5ff",
+              "on-tertiary-fixed-variant": "#00429c",
+              "on-secondary-fixed-variant": "#343d96",
+              "inverse-surface": "#dbe2f8",
+              "inverse-primary": "#006875",
+              "surface-container": "#18202f",
+              surface: "#0b1323",
+              "on-primary-container": "#00626e",
+              "on-primary-fixed": "#001f24",
+              error: "#ffb4ab",
+              "surface-container-high": "#222a3a",
+              "secondary-fixed": "#e0e0ff",
+              "on-secondary-container": "#a8afff",
+              "tertiary-fixed-dim": "#b0c6ff",
+              "secondary-container": "#343d96",
+              "primary-fixed-dim": "#00daf3",
+              tertiary: "#e8ecff",
+              "on-tertiary-container": "#2455af",
+              "on-primary-fixed-variant": "#004f58",
+              "on-secondary-fixed": "#000767",
+              primary: "#c3f5ff",
+              background: "#0b1323",
+              "on-tertiary": "#002d6f",
+              "on-primary": "#00363d",
+              "on-error-container": "#ffdad6",
+              "inverse-on-surface": "#283041",
+              "surface-variant": "#2d3546",
+              "surface-container-highest": "#2d3546",
+              secondary: "#bdc2ff",
+              outline: "#849396",
+              "on-surface-variant": "#bac9cc",
+              "surface-bright": "#31394a",
+              "primary-fixed": "#9cf0ff",
+              "tertiary-fixed": "#d9e2ff",
+              "surface-dim": "#0b1323",
+              "on-surface": "#dbe2f8",
+              "secondary-fixed-dim": "#bdc2ff",
+            },
+            borderRadius: {
+              DEFAULT: "0.125rem",
+              lg: "0.25rem",
+              xl: "0.5rem",
+              full: "0.75rem",
+            },
+            spacing: {
+              xs: "4px",
+              margin: "24px",
+              lg: "24px",
+              xl: "40px",
+              gutter: "16px",
+              base: "4px",
+              sm: "8px",
+              md: "16px",
+            },
+            fontFamily: {
+              "headline-lg": ["Geist"],
+              "title-md": ["Geist"],
+              "label-sm": ["JetBrains Mono"],
+              "body-sm": ["Geist"],
+              "body-lg": ["Geist"],
+              "display-lg": ["Geist"],
+            },
+          },
+        },
+      };
+    </script>
+    <style>
+      .material-symbols-outlined {
+        font-variation-settings:
+          "FILL" 0,
+          "wght" 400,
+          "GRAD" 0,
+          "opsz" 24;
+      }
+      .service-card {
+        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+      }
+      .service-card:hover {
+        border-color: #00e5ff;
+        box-shadow: 0 0 20px rgba(0, 229, 255, 0.1);
+        transform: translateY(-4px);
+      }
+      .active-indicator {
+        position: absolute;
+        left: 0;
+        top: 20%;
+        bottom: 20%;
+        width: 2px;
+        background-color: #00e5ff;
+      }
+    </style>
+  </head>
+  <body
+    class="bg-background text-on-background font-body-lg overflow-x-hidden selection:bg-primary-container selection:text-on-primary-container"
+  >
+    <!-- TopNavBar -->
+    <header
+      class="fixed top-0 left-0 right-0 z-50 bg-surface-container-lowest border-b border-outline-variant"
+    >
+      <nav
+        class="flex justify-between items-center px-lg py-md w-full max-w-7xl mx-auto h-20"
+      >
+        <div class="flex items-center gap-sm">
+          <span
+            class="font-headline-lg text-headline-lg font-bold text-primary-fixed-dim tracking-tight"
+            >Leigh Services</span
+          >
+        </div>
+        <div class="hidden md:flex items-center gap-lg">
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="index.html"
+            >Home</a
+          >
+          <a
+            class="text-primary-fixed-dim font-bold border-b-2 border-primary-fixed-dim pb-1 transition-colors duration-200"
+            href="services.html"
+            >Services</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="team.html"
+            >Meet the Team</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="certifications.html"
+            >Certifications</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="case-studies.html"
+            >Case Studies</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="testimonials.html"
+            >Testimonials</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="blog.html"
+            >Blog</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="contact.html"
+            >Contact</a
+          >
+          <a
+            class="ml-md px-md py-sm bg-primary-container text-on-primary-container font-bold rounded hover:opacity-90 transition-all"
+            href="contact.html"
+            >Consultation</a
+          >
+        </div>
+        <!-- Mobile Menu Toggle -->
+        <button
+          class="md:hidden text-on-surface"
+          onclick="
+            document.getElementById('mobile-menu').classList.toggle('hidden')
+          "
+          aria-label="Open menu"
+        >
+          <span class="material-symbols-outlined">menu</span>
+        </button>
+      </nav>
+    </header>
 
-		<!-- Nav -->
-			<nav id="menu">
-				<ul class="links">
-					<li><a href="index.html">Home</a></li>
-					<li><a href="services.html">Services</a></li>
-					<li><a href="team.html">Meet the Team</a></li>
-					<li><a href="certifications.html">Certifications</a></li>
-					<li><a href="case-studies.html">Case Studies</a></li>
-					<li><a href="testimonials.html">Testimonials</a></li>
-					<li><a href="blog.html">Blog</a></li>
-					<li><a href="contact.html">Contact</a></li>
-				</ul>
-			</nav>
+    <!-- Mobile Menu -->
+    <div
+      class="hidden md:hidden fixed inset-0 z-[110] bg-surface-container-lowest p-lg"
+      id="mobile-menu"
+    >
+      <div class="flex flex-col gap-md">
+        <div class="flex justify-between items-center mb-xl">
+          <span
+            class="font-headline-lg-mobile text-headline-lg-mobile text-primary-fixed-dim"
+            >Leigh Services</span
+          >
+          <button
+            onclick="
+              document.getElementById('mobile-menu').classList.add('hidden')
+            "
+            aria-label="Close menu"
+          >
+            <span class="material-symbols-outlined">close</span>
+          </button>
+        </div>
+        <a class="text-title-md py-sm" href="index.html">Home</a>
+        <a
+          class="text-title-md py-sm text-primary-fixed-dim font-bold"
+          href="services.html"
+          >Services</a
+        >
+        <a class="text-title-md py-sm" href="team.html">Meet the Team</a>
+        <a class="text-title-md py-sm" href="certifications.html"
+          >Certifications</a
+        >
+        <a class="text-title-md py-sm" href="case-studies.html">Case Studies</a>
+        <a class="text-title-md py-sm" href="testimonials.html">Testimonials</a>
+        <a class="text-title-md py-sm" href="blog.html">Blog</a>
+        <a class="text-title-md py-sm" href="contact.html">Contact</a>
+        <a
+          class="mt-md bg-primary-container text-on-primary-container text-center px-md py-md rounded font-bold"
+          href="contact.html"
+          >Consultation</a
+        >
+      </div>
+    </div>
+    <main class="pt-32 pb-xl">
+      <!-- Hero Section -->
+      <section class="max-w-7xl mx-auto px-lg mb-xl relative overflow-hidden">
+        <div class="relative z-10 py-xl max-w-3xl">
+          <h1
+            class="font-display-lg text-display-lg text-primary-fixed-dim mb-md"
+          >
+            Expert IT &amp; Data Infrastructure
+          </h1>
+          <p
+            class="text-on-surface-variant font-body-lg text-lg leading-relaxed mb-lg"
+          >
+            Leigh Services brings together deep expertise across infrastructure
+            engineering, automation, data platforms and security compliance —
+            delivering reliable, well-engineered solutions for organisations of
+            all sizes.
+          </p>
+        </div>
+      </section>
+      <!-- Services Grid - High-End Bento Style -->
+      <section class="max-w-7xl mx-auto px-lg">
+        <div class="grid grid-cols-1 md:grid-cols-12 gap-md">
+          <!-- IT Infrastructure -->
+          <div
+            class="md:col-span-8 service-card bg-surface-container p-xl border border-outline-variant relative group"
+            id="it-infrastructure"
+          >
+            <div
+              class="active-indicator opacity-0 group-hover:opacity-100 transition-opacity"
+            ></div>
+            <div class="flex items-start justify-between mb-lg">
+              <span
+                class="material-symbols-outlined text-primary-fixed-dim text-4xl"
+                style="font-variation-settings: &quot;FILL&quot; 1"
+                >dns</span
+              >
+              <span
+                class="font-label-sm text-label-sm text-outline px-sm py-xs border border-outline rounded"
+                >CORE INFRA</span
+              >
+            </div>
+            <h3 class="font-headline-lg text-headline-lg mb-md text-on-surface">
+              IT Infrastructure
+            </h3>
+            <p
+              class="text-on-surface-variant font-body-lg mb-xl leading-relaxed"
+            >
+              End-to-end infrastructure design, implementation and support. From
+              server management and virtualisation to Microsoft 365 and Azure
+              deployments — we keep your systems running reliably and securely.
+            </p>
+            <div class="flex flex-wrap gap-sm">
+              <span
+                class="font-label-md text-label-md bg-surface-container-high px-md py-xs text-secondary"
+                >Azure / M365</span
+              >
+              <span
+                class="font-label-md text-label-md bg-surface-container-high px-md py-xs text-secondary"
+                >VMware</span
+              >
+              <span
+                class="font-label-md text-label-md bg-surface-container-high px-md py-xs text-secondary"
+                >On-prem Migration</span
+              >
+            </div>
+          </div>
+          <!-- PowerShell & Automation -->
+          <div
+            class="md:col-span-4 service-card bg-surface-container p-xl border border-outline-variant relative group"
+            id="powershell-automation"
+          >
+            <div
+              class="active-indicator opacity-0 group-hover:opacity-100 transition-opacity"
+            ></div>
+            <span
+              class="material-symbols-outlined text-primary-fixed-dim text-4xl mb-lg"
+              style="font-variation-settings: &quot;FILL&quot; 1"
+              >terminal</span
+            >
+            <h3 class="font-headline-lg text-headline-lg mb-md text-on-surface">
+              PowerShell &amp; Automation
+            </h3>
+            <p
+              class="text-on-surface-variant font-body-sm leading-relaxed mb-lg"
+            >
+              Specialist PowerShell development for infrastructure automation,
+              toolmaking and DevOps workflows. From custom modules to scheduled
+              jobs, we remove manual effort and enforce consistency at scale.
+            </p>
+            <div class="w-full h-32 mt-auto">
+              <div
+                class="bg-surface-container-lowest p-md rounded font-label-md text-primary opacity-60"
+              >
+                <code
+                  >Get-Service | Where-Object {$_.Status -eq "Running"}</code
+                >
+              </div>
+            </div>
+          </div>
+          <!-- Cloud Solutions -->
+          <div
+            class="md:col-span-4 service-card bg-surface-container p-xl border border-outline-variant relative group"
+            id="cloud-solutions"
+          >
+            <div
+              class="active-indicator opacity-0 group-hover:opacity-100 transition-opacity"
+            ></div>
+            <span
+              class="material-symbols-outlined text-primary-fixed-dim text-4xl mb-lg"
+              style="font-variation-settings: &quot;FILL&quot; 1"
+              >cloud_done</span
+            >
+            <h3 class="font-headline-lg text-headline-lg mb-md text-on-surface">
+              Cloud Solutions
+            </h3>
+            <p class="text-on-surface-variant font-body-sm leading-relaxed">
+              Cloud architecture and migration across Microsoft Azure and Google
+              Cloud Platform. Licensing, identity, storage, networking and SaaS
+              integration — designed for security and cost-efficiency.
+            </p>
+          </div>
+          <!-- Data Engineering -->
+          <div
+            class="md:col-span-8 service-card bg-surface-container p-xl border border-outline-variant relative group flex flex-col md:flex-row gap-lg items-center"
+            id="data-engineering"
+          >
+            <div
+              class="active-indicator opacity-0 group-hover:opacity-100 transition-opacity"
+            ></div>
+            <div class="flex-1">
+              <div class="flex items-center gap-sm mb-md">
+                <span
+                  class="material-symbols-outlined text-primary-fixed-dim text-3xl"
+                  style="font-variation-settings: &quot;FILL&quot; 1"
+                  >database</span
+                >
+                <h3 class="font-headline-lg text-headline-lg text-on-surface">
+                  Data Engineering
+                </h3>
+              </div>
+              <p class="text-on-surface-variant font-body-lg mb-lg">
+                Building and stabilising data pipelines and improving integrity
+                and reliability. From legacy SAS migrations to modern cloud data
+                lakes, we make your data accurate, complete and trustworthy.
+              </p>
+              <div class="flex flex-wrap gap-xs">
+                <span
+                  class="font-label-sm text-label-sm px-sm py-1 bg-primary text-on-primary"
+                  >SAS-TO-GCP</span
+                >
+                <span
+                  class="font-label-sm text-label-sm px-sm py-1 bg-primary text-on-primary"
+                  >PIPELINE TUNING</span
+                >
+              </div>
+            </div>
+            <div
+              class="w-full md:w-1/3 aspect-video overflow-hidden border border-outline-variant bg-surface-container-high flex items-center justify-center"
+            >
+              <span
+                class="material-symbols-outlined text-primary-fixed-dim/30"
+                style="
+                  font-size: 80px;
+                  font-variation-settings: &quot;FILL&quot; 1;
+                "
+                >database</span
+              >
+            </div>
+          </div>
+          <!-- Security & Compliance -->
+          <div
+            class="md:col-span-6 service-card bg-surface-container p-xl border border-outline-variant relative group"
+            id="security-compliance"
+          >
+            <div
+              class="active-indicator opacity-0 group-hover:opacity-100 transition-opacity"
+            ></div>
+            <div class="flex items-start gap-md">
+              <div class="bg-surface-container-high p-md rounded">
+                <span
+                  class="material-symbols-outlined text-error text-3xl"
+                  style="font-variation-settings: &quot;FILL&quot; 1"
+                  >shield_with_heart</span
+                >
+              </div>
+              <div>
+                <h3
+                  class="font-headline-lg text-headline-lg mb-md text-on-surface"
+                >
+                  Security &amp; Compliance
+                </h3>
+                <p class="text-on-surface-variant font-body-lg leading-relaxed">
+                  PCI DSS compliance, security hardening, Active Directory
+                  governance and audit-ready frameworks. Practical security
+                  delivered by engineers who have achieved compliance on
+                  real-world complex infrastructures.
+                </p>
+              </div>
+            </div>
+          </div>
+          <!-- DevSecOps -->
+          <div
+            class="md:col-span-6 service-card bg-surface-container p-xl border border-outline-variant relative group"
+            id="devsecops"
+          >
+            <div
+              class="active-indicator opacity-0 group-hover:opacity-100 transition-opacity"
+            ></div>
+            <div class="flex items-start gap-md">
+              <div class="bg-surface-container-high p-md rounded">
+                <span
+                  class="material-symbols-outlined text-primary-fixed-dim text-3xl"
+                  style="font-variation-settings: &quot;FILL&quot; 1"
+                  >all_inclusive</span
+                >
+              </div>
+              <div>
+                <h3
+                  class="font-headline-lg text-headline-lg mb-md text-on-surface"
+                >
+                  DevSecOps
+                </h3>
+                <p class="text-on-surface-variant font-body-lg leading-relaxed">
+                  Integrating security into platforms from the ground up.
+                  Pipeline hardening, vulnerability management, SIEM analysis
+                  and risk reduction built into your development and operational
+                  processes.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <!-- Ready to work together -->
+      <section class="max-w-7xl mx-auto px-lg mt-xl">
+        <div
+          class="bg-primary-container p-xl flex flex-col md:flex-row items-center justify-between gap-xl"
+        >
+          <div class="max-w-2xl">
+            <h2
+              class="font-display-lg text-display-lg text-on-primary-container mb-md"
+            >
+              Ready to work together?
+            </h2>
+            <p class="text-on-primary-container text-lg font-medium opacity-90">
+              Whether you need infrastructure support, automation tooling, data
+              platform engineering or compliance guidance — we bring the
+              expertise to get the job done. Get in touch and let's talk about
+              what we can do for you.
+            </p>
+          </div>
+          <a
+            class="px-xl py-lg bg-surface-container-lowest text-primary-fixed-dim font-bold text-headline-lg rounded hover:scale-105 transition-transform duration-300 shadow-xl"
+            href="contact.html"
+          >
+            Get in Touch
+          </a>
+        </div>
+      </section>
+    </main>
+    <!-- Footer -->
+    <footer class="bg-surface-container-lowest border-t border-outline-variant">
+      <div
+        class="grid grid-cols-1 md:grid-cols-4 gap-xl px-lg py-xl max-w-7xl mx-auto"
+      >
+        <div class="md:col-span-1">
+          <span
+            class="font-title-md text-title-md font-bold text-primary-fixed-dim block mb-md"
+            >Leigh Services</span
+          >
+          <p class="font-body-sm text-body-sm text-on-surface-variant mb-lg">
+            Expert IT Infrastructure, Automation and Data Engineering consulting
+            based in Southend-on-Sea, Essex.
+          </p>
+          <p class="font-body-sm text-body-sm text-on-surface-variant">
+            63 Archer Avenue,<br />Southend on Sea,<br />Essex SS2 4QU
+          </p>
+        </div>
+        <div>
+          <h4
+            class="text-primary-fixed-dim font-bold mb-md uppercase tracking-wider text-xs"
+          >
+            Services
+          </h4>
+          <ul class="space-y-sm">
+            <li>
+              <a
+                class="text-on-surface-variant hover:text-primary transition-colors text-body-sm"
+                href="services.html#it-infrastructure"
+                >IT Infrastructure</a
+              >
+            </li>
+            <li>
+              <a
+                class="text-on-surface-variant hover:text-primary transition-colors text-body-sm"
+                href="services.html#powershell-automation"
+                >PowerShell &amp; Automation</a
+              >
+            </li>
+            <li>
+              <a
+                class="text-on-surface-variant hover:text-primary transition-colors text-body-sm"
+                href="services.html#cloud-solutions"
+                >Cloud Solutions</a
+              >
+            </li>
+            <li>
+              <a
+                class="text-on-surface-variant hover:text-primary transition-colors text-body-sm"
+                href="services.html#data-engineering"
+                >Data Engineering</a
+              >
+            </li>
+            <li>
+              <a
+                class="text-on-surface-variant hover:text-primary transition-colors text-body-sm"
+                href="services.html#security-compliance"
+                >Security &amp; Compliance</a
+              >
+            </li>
+            <li>
+              <a
+                class="text-on-surface-variant hover:text-primary transition-colors text-body-sm"
+                href="services.html#devsecops"
+                >DevSecOps</a
+              >
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h4
+            class="text-primary-fixed-dim font-bold mb-md uppercase tracking-wider text-xs"
+          >
+            Explore
+          </h4>
+          <ul class="space-y-sm">
+            <li>
+              <a
+                class="text-on-surface-variant hover:text-primary transition-colors text-body-sm"
+                href="index.html"
+                >Home</a
+              >
+            </li>
+            <li>
+              <a
+                class="text-on-surface-variant hover:text-primary transition-colors text-body-sm"
+                href="team.html"
+                >Meet the Team</a
+              >
+            </li>
+            <li>
+              <a
+                class="text-on-surface-variant hover:text-primary transition-colors text-body-sm"
+                href="certifications.html"
+                >Certifications</a
+              >
+            </li>
+            <li>
+              <a
+                class="text-on-surface-variant hover:text-primary transition-colors text-body-sm"
+                href="case-studies.html"
+                >Case Studies</a
+              >
+            </li>
+            <li>
+              <a
+                class="text-on-surface-variant hover:text-primary transition-colors text-body-sm"
+                href="testimonials.html"
+                >Testimonials</a
+              >
+            </li>
+            <li>
+              <a
+                class="text-on-surface-variant hover:text-primary transition-colors text-body-sm"
+                href="blog.html"
+                >Blog</a
+              >
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h4
+            class="text-primary-fixed-dim font-bold mb-md uppercase tracking-wider text-xs"
+          >
+            Connect
+          </h4>
+          <ul class="space-y-sm">
+            <li>
+              <a
+                class="text-on-surface-variant hover:text-primary transition-colors text-body-sm flex items-center gap-xs"
+                href="https://www.linkedin.com/in/lukeleigh"
+                >Luke on LinkedIn</a
+              >
+            </li>
+            <li>
+              <a
+                class="text-on-surface-variant hover:text-primary transition-colors text-body-sm flex items-center gap-xs"
+                href="https://www.linkedin.com/in/markleigh"
+                >Mark on LinkedIn</a
+              >
+            </li>
+            <li>
+              <a
+                class="text-on-surface-variant hover:text-primary transition-colors text-body-sm flex items-center gap-xs"
+                href="https://github.com/BanterBoy"
+                >GitHub (BanterBoy)</a
+              >
+            </li>
+            <li>
+              <a
+                class="text-on-surface-variant hover:text-primary transition-colors text-body-sm flex items-center gap-xs"
+                href="https://blog.lukeleigh.com"
+                >Luke's Blog</a
+              >
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div
+        class="max-w-7xl mx-auto px-lg py-md border-t border-outline-variant flex justify-between items-center"
+      >
+        <p class="font-body-sm text-body-sm text-on-surface-variant opacity-60">
+          © 2024-2026 Leigh IT Services Ltd. All rights reserved.
+        </p>
+      </div>
+    </footer>
+    <script>
+      // Intersection Observer for highlighting the active section in nav if it was on a single page,
+      // but since it's a dedicated Services page we just ensure the hash links scroll nicely.
+      document
+        .querySelectorAll('a[href^="services.html#"]')
+        .forEach((anchor) => {
+          anchor.addEventListener("click", function (e) {
+            const targetId = this.getAttribute("href").split("#")[1];
+            const targetElement = document.getElementById(targetId);
+            if (targetElement) {
+              e.preventDefault();
+              window.scrollTo({
+                top: targetElement.offsetTop - 100,
+                behavior: "smooth",
+              });
+            }
+          });
+        });
 
-		<!-- Heading -->
-			<div id="heading">
-				<h1>Our Services</h1>
-			</div>
+      // Simple scroll reveal for cards
+      const observerOptions = {
+        threshold: 0.1,
+      };
 
-		<!-- Main -->
-			<section id="main" class="wrapper">
-				<div class="inner">
-					<div class="content">
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("opacity-100", "translate-y-0");
+            entry.target.classList.remove("opacity-0", "translate-y-8");
+          }
+        });
+      }, observerOptions);
 
-						<header>
-							<h2>What We Do</h2>
-							<p>Leigh Services brings together deep expertise across infrastructure engineering, automation, data platforms and security compliance. We work with organisations of all sizes to deliver reliable, well-engineered solutions — without the overhead of a large consultancy.</p>
-						</header>
-
-						<!-- IT Infrastructure -->
-						<div class="service-section" id="it-infrastructure">
-							<p class="service-icon"><i class="icon fa-server"></i></p>
-							<h2>IT Infrastructure</h2>
-							<p>End-to-end infrastructure design, implementation and ongoing support. From server management and virtualisation to Microsoft 365 and Azure deployments — we keep your systems running reliably and securely.</p>
-							<p>Our infrastructure work spans on-premises, hybrid and cloud environments. We have delivered projects across retail, financial services, insurance and managed service providers — including full data centre migrations, Exchange deployments, VMware virtualisation, and network redesigns. Where many engineers handle individual components, we understand how the whole system fits together.</p>
-							<p>Key areas: Windows Server, Active Directory, VMware, Microsoft 365, Exchange Online, Azure, Hyper-V, Mimecast, Juniper networking.</p>
-							<p class="service-cta"><a href="contact.html" class="button small">Discuss Your Infrastructure</a></p>
-						</div>
-
-						<!-- PowerShell & Automation -->
-						<div class="service-section" id="powershell-automation">
-							<p class="service-icon"><i class="icon fa-cogs"></i></p>
-							<h2>PowerShell &amp; Automation</h2>
-							<p>Specialist PowerShell development for infrastructure automation, toolmaking and DevOps workflows. From custom modules and scheduled jobs to full automation pipelines — we remove manual effort and enforce consistency at scale.</p>
-							<p>Luke has been writing production PowerShell since 2008 and publishes open-source tooling on GitHub and the PowerShell Gallery. We build automation that is readable, maintainable and safe — including error handling, logging, testing and documentation as standard, not as an afterthought.</p>
-							<p>Key areas: PowerShell modules, CI/CD integration, Exchange automation, Active Directory scripting, scheduled tasks, DSC, GitHub Actions.</p>
-							<p class="service-cta"><a href="contact.html" class="button small">Talk Automation</a></p>
-						</div>
-
-						<!-- Cloud Solutions -->
-						<div class="service-section" id="cloud-solutions">
-							<p class="service-icon"><i class="icon fa-cloud"></i></p>
-							<h2>Cloud Solutions</h2>
-							<p>Cloud architecture, migration and ongoing management across Microsoft Azure and Google Cloud Platform. We handle licensing, identity, storage, networking and SaaS integration — designed for security and cost-efficiency from the outset.</p>
-							<p>We have delivered on-premises to Microsoft 365 migrations including Exchange Online, Teams, SharePoint and Azure Active Directory. On the GCP side, Mark led a complex platform migration at Swarovski — delivering €1m in annual cost savings within 9 months. Whether you are starting your cloud journey or optimising an existing footprint, we provide the engineering expertise to do it properly.</p>
-							<p>Key areas: Microsoft Azure, GCP, Microsoft 365, Exchange Online, Azure AD / Entra ID, Teams, SharePoint, cloud security posture.</p>
-							<p class="service-cta"><a href="contact.html" class="button small">Plan Your Cloud Move</a></p>
-						</div>
-
-						<!-- Data Engineering -->
-						<div class="service-section" id="data-engineering">
-							<p class="service-icon"><i class="icon fa-database"></i></p>
-							<h2>Data Engineering</h2>
-							<p>Building and stabilising data pipelines, and improving the integrity and reliability of data platforms. From legacy SAS migrations to modern cloud data lakes, we make your data accurate, complete and trustworthy.</p>
-							<p>Much of our data engineering work begins when something is not quite right — pipelines that fail silently, data that cannot be trusted, or reports that contradict each other. We specialise in root cause analysis and remediation: diagnosing what is actually wrong beneath the surface, and putting in place solutions that are stable, predictable and auditable.</p>
-							<p>Key areas: Python, SQL, SAS, Google Cloud Platform, BigQuery, data pipeline security, data integrity &amp; lineage, regulatory reporting (FINREP, Basel).</p>
-							<p class="service-cta"><a href="contact.html" class="button small">Talk Data Engineering</a></p>
-						</div>
-
-						<!-- Security & Compliance -->
-						<div class="service-section" id="security-compliance">
-							<p class="service-icon"><i class="icon fa-shield"></i></p>
-							<h2>Security &amp; Compliance</h2>
-							<p>PCI DSS compliance, security hardening, Active Directory governance and audit-ready frameworks. Practical security delivered by engineers who have achieved compliance on real-world, complex infrastructures under genuine time pressure.</p>
-							<p>Luke led a PCI DSS compliance programme at Insure and Go spanning eight years — owning the WAN infrastructure and delivering compliance across four offices and a full data centre migration. He subsequently delivered a full PCI compliance programme at Ventrica within a fixed deadline. Mark holds CompTIA Security+ and is progressing CREST CPSA, bringing a security-first perspective to data platform design and DevSecOps practices.</p>
-							<p>Key areas: PCI DSS, ISO 27001, Active Directory hardening, firewall management, patch governance, SIEM, vulnerability management, audit readiness.</p>
-							<p class="service-cta"><a href="contact.html" class="button small">Discuss Security &amp; Compliance</a></p>
-						</div>
-
-						<!-- DevSecOps -->
-						<div class="service-section" id="devsecops">
-							<p class="service-icon"><i class="icon fa-lock"></i></p>
-							<h2>DevSecOps</h2>
-							<p>Integrating security into platforms from the ground up. Pipeline hardening, vulnerability management, SIEM analysis and risk reduction — built into your development and operational processes rather than bolted on afterwards.</p>
-							<p>We approach DevSecOps as a discipline that belongs at the engineering level, not as a separate audit function. Mark's data engineering work is informed by security considerations at every stage — from pipeline design and access control to secret management and incident detection. Across both disciplines, we help organisations move towards a posture where security is a property of the system, not a checklist.</p>
-							<p>Key areas: pipeline security, secrets management, container security, dependency scanning, SIEM analysis, GitHub Actions security, policy as code.</p>
-							<p class="service-cta"><a href="contact.html" class="button small">Talk DevSecOps</a></p>
-						</div>
-
-					</div>
-				</div>
-			</section>
-
-		<!-- Footer -->
-			<footer id="footer">
-				<div class="inner">
-					<div class="content">
-						<section>
-							<h3>Leigh Services</h3>
-							<p>Expert IT Infrastructure, Automation and Data Engineering consulting based in Southend-on-Sea, Essex. Serving clients across the UK and internationally.</p>
-							<p>63 Archer Avenue, Southend on Sea, Essex SS2 4QU</p>
-						</section>
-						<section>
-							<h4>Services</h4>
-							<ul class="alt">
-								<li><a href="services.html#it-infrastructure">IT Infrastructure</a></li>
-								<li><a href="services.html#powershell-automation">PowerShell &amp; Automation</a></li>
-								<li><a href="services.html#cloud-solutions">Cloud Solutions</a></li>
-								<li><a href="services.html#data-engineering">Data Engineering</a></li>
-								<li><a href="services.html#security-compliance">Security &amp; Compliance</a></li>
-								<li><a href="services.html#devsecops">DevSecOps</a></li>
-							</ul>
-						</section>
-						<section>
-							<h4>Connect</h4>
-							<ul class="plain">
-								<li><a href="https://www.linkedin.com/in/lukeleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>Luke on LinkedIn</a></li>
-								<li><a href="https://www.linkedin.com/in/markleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>Mark on LinkedIn</a></li>
-								<li><a href="https://github.com/BanterBoy" target="_blank" rel="noopener noreferrer"><i class="icon fa-github">&nbsp;</i>GitHub (BanterBoy)</a></li>
-								<li><a href="https://blog.lukeleigh.com" target="_blank" rel="noopener noreferrer"><i class="icon fa-rss">&nbsp;</i>Luke's Blog</a></li>
-							</ul>
-						</section>
-					</div>
-					<div class="copyright">
-						&copy; 2024&ndash;2026 Leigh IT Services Ltd. All rights reserved.
-					</div>
-				</div>
-			</footer>
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
-
-	</body>
+      document.querySelectorAll(".service-card").forEach((card) => {
+        card.classList.add(
+          "opacity-0",
+          "translate-y-8",
+          "transition-all",
+          "duration-700",
+        );
+        observer.observe(card);
+      });
+    </script>
+  </body>
 </html>

--- a/services.html
+++ b/services.html
@@ -137,9 +137,10 @@
         class="flex justify-between items-center px-lg py-md w-full max-w-7xl mx-auto h-20"
       >
         <div class="flex items-center gap-sm">
-          <span
+          <a
             class="font-headline-lg text-headline-lg font-bold text-primary-fixed-dim tracking-tight"
-            >Leigh Services</span
+            href="index.html"
+            >Leigh Services</a
           >
         </div>
         <div class="hidden md:flex items-center gap-lg">

--- a/team.html
+++ b/team.html
@@ -1,391 +1,1110 @@
-<!DOCTYPE HTML>
-<html lang="en-gb">
-	<head>
-		<title>Meet the Team | Leigh Services</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<meta name="description" content="Meet Luke Leigh and Mark Leigh — the founders and owners of Leigh Services, bringing 50+ years of IT infrastructure and data engineering expertise." />
-		<meta name="keywords" content="Luke Leigh, Mark Leigh, Leigh Services, IT infrastructure, PowerShell, data engineering, security" />
-		<meta http-equiv="content-language" content="en-gb" />
-		<link rel="canonical" href="https://leigh-services.com/team.html" />
-		<meta property="og:type" content="website" />
-		<meta property="og:site_name" content="Leigh Services" />
-		<meta property="og:title" content="Meet the Team | Leigh Services" />
-		<meta property="og:description" content="Meet Luke Leigh and Mark Leigh — the founders and owners of Leigh Services, bringing 50+ years of IT infrastructure and data engineering expertise." />
-		<meta property="og:url" content="https://leigh-services.com/team.html" />
-		<meta property="og:image" content="https://leigh-services.com/images/banner.jpg" />
-		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Meet the Team | Leigh Services" />
-		<meta name="twitter:description" content="Meet Luke Leigh and Mark Leigh — the founders and owners of Leigh Services, bringing 50+ years of IT infrastructure and data engineering expertise." />
-		<meta name="twitter:image" content="https://leigh-services.com/images/banner.jpg" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<style>
-			/* Profile layout */
-			.profile-section {
-				display: -ms-flexbox;
-				display: flex;
-				-ms-flex-wrap: wrap;
-				flex-wrap: wrap;
-				gap: 3em;
-				align-items: flex-start;
-				padding: 3em 0;
-				border-bottom: 1px solid #e4e4e4;
-			}
-			.profile-section:last-of-type {
-				border-bottom: none;
-			}
-			.profile-photo {
-				-ms-flex: 0 0 260px;
-				flex: 0 0 260px;
-				max-width: 260px;
-			}
-			/* Photo wrapper — 4:3 aspect ratio */
-			.profile-photo .photo-wrap {
-				position: relative;
-				width: 100%;
-				padding-top: 125%; /* taller crop for portrait headshots */
-				border-radius: 4px;
-				overflow: hidden;
-				margin-bottom: 1.2em;
-			}
-			.profile-photo .photo-wrap img {
-				position: absolute;
-				top: 0; left: 0;
-				width: 100%;
-				height: 100%;
-				object-fit: cover;
-				object-position: center top;
-				display: block;
-			}
-			.profile-photo .photo-meta {
-				margin-top: 1.2em;
-			}
-			.profile-photo .photo-meta a {
-				display: block;
-				color: #ce1b28;
-				font-size: 0.88em;
-				font-weight: 600;
-				margin-bottom: 0.4em;
-				text-decoration: none;
-			}
-			.profile-photo .photo-meta a:hover {
-				text-decoration: underline;
-			}
-			.profile-body {
-				-ms-flex: 1 1 320px;
-				flex: 1 1 320px;
-			}
-			.profile-body h2 {
-				margin-bottom: 0.15em;
-			}
-			.profile-role {
-				color: #ce1b28;
-				font-size: 0.8em;
-				font-weight: 700;
-				text-transform: uppercase;
-				letter-spacing: 0.12em;
-				margin: 0 0 1.2em 0;
-			}
-			.profile-body p {
-				color: #555;
-				line-height: 1.75;
-				margin-bottom: 1em;
-			}
-			.profile-body h4 {
-				margin: 1.6em 0 0.6em 0;
-				font-size: 0.85em;
-				text-transform: uppercase;
-				letter-spacing: 0.1em;
-				color: #111;
-			}
-			.skill-tags {
-				display: -ms-flexbox;
-				display: flex;
-				-ms-flex-wrap: wrap;
-				flex-wrap: wrap;
-				gap: 0.4em;
-				margin-bottom: 1.2em;
-			}
-			.skill-tag {
-				background: #111;
-				color: #fff;
-				font-size: 0.72em;
-				font-weight: 600;
-				letter-spacing: 0.05em;
-				padding: 0.3em 0.8em;
-				border-radius: 2px;
-			}
-			.exp-item {
-				margin-bottom: 1.2em;
-			}
-			.exp-item strong {
-				display: block;
-				font-size: 0.95em;
-				color: #111;
-			}
-			.exp-item span {
-				font-size: 0.82em;
-				color: #888;
-			}
-			.exp-item p {
-				margin-top: 0.4em;
-				font-size: 0.9em;
-				margin-bottom: 0;
-			}
-			@media screen and (max-width: 640px) {
-				.profile-photo {
-					-ms-flex: 0 0 100%;
-					flex: 0 0 100%;
-					max-width: 100%;
-				}
-				.profile-photo .photo-wrap {
+﻿<!doctype html>
+<html class="dark" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Meet the Team | Leigh Services</title>
+    <meta
+      name="description"
+      content="Meet Luke Leigh and Mark Leigh — the founders of Leigh Services, bringing 50+ years of IT infrastructure, automation and data engineering expertise."
+    />
+    <meta
+      name="keywords"
+      content="Luke Leigh, Mark Leigh, Leigh Services, IT infrastructure, PowerShell, data engineering, security"
+    />
+    <link rel="canonical" href="https://leigh-services.com/team.html" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Leigh Services" />
+    <meta property="og:title" content="Meet the Team | Leigh Services" />
+    <meta
+      property="og:description"
+      content="Meet Luke Leigh and Mark Leigh — the founders of Leigh Services, bringing 50+ years of IT infrastructure and data engineering expertise."
+    />
+    <meta property="og:url" content="https://leigh-services.com/team.html" />
+    <meta
+      property="og:image"
+      content="https://leigh-services.com/images/banner.jpg"
+    />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&amp;family=Geist:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <script id="tailwind-config">
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            colors: {
+              "surface-container-low": "#131c2b",
+              "outline-variant": "#3b494c",
+              "on-error": "#690005",
+              "on-tertiary-fixed": "#001945",
+              "surface-container-lowest": "#060e1d",
+              "on-background": "#dbe2f8",
+              "error-container": "#93000a",
+              "on-secondary": "#1b247f",
+              "surface-tint": "#00daf3",
+              "tertiary-container": "#bfd0ff",
+              "primary-container": "#00e5ff",
+              "on-tertiary-fixed-variant": "#00429c",
+              "on-secondary-fixed-variant": "#343d96",
+              "inverse-surface": "#dbe2f8",
+              "inverse-primary": "#006875",
+              "surface-container": "#18202f",
+              surface: "#0b1323",
+              "on-primary-container": "#00626e",
+              "on-primary-fixed": "#001f24",
+              error: "#ffb4ab",
+              "surface-container-high": "#222a3a",
+              "secondary-fixed": "#e0e0ff",
+              "on-secondary-container": "#a8afff",
+              "tertiary-fixed-dim": "#b0c6ff",
+              "secondary-container": "#343d96",
+              "primary-fixed-dim": "#00daf3",
+              tertiary: "#e8ecff",
+              "on-tertiary-container": "#2455af",
+              "on-primary-fixed-variant": "#004f58",
+              "on-secondary-fixed": "#000767",
+              primary: "#c3f5ff",
+              background: "#0b1323",
+              "on-tertiary": "#002d6f",
+              "on-primary": "#00363d",
+              "on-error-container": "#ffdad6",
+              "inverse-on-surface": "#283041",
+              "surface-variant": "#2d3546",
+              "surface-container-highest": "#2d3546",
+              secondary: "#bdc2ff",
+              outline: "#849396",
+              "on-surface-variant": "#bac9cc",
+              "surface-bright": "#31394a",
+              "primary-fixed": "#9cf0ff",
+              "tertiary-fixed": "#d9e2ff",
+              "surface-dim": "#0b1323",
+              "on-surface": "#dbe2f8",
+              "secondary-fixed-dim": "#bdc2ff",
+            },
+            borderRadius: {
+              DEFAULT: "0.125rem",
+              lg: "0.25rem",
+              xl: "0.5rem",
+              full: "0.75rem",
+            },
+            spacing: {
+              xs: "4px",
+              margin: "24px",
+              lg: "24px",
+              xl: "40px",
+              gutter: "16px",
+              base: "4px",
+              sm: "8px",
+              md: "16px",
+            },
+            fontFamily: {
+              "headline-lg-mobile": ["Geist"],
+              "title-md": ["Geist"],
+              "label-sm": ["JetBrains Mono"],
+              "headline-lg": ["Geist"],
+              "body-sm": ["Geist"],
+              "label-md": ["JetBrains Mono"],
+              "body-lg": ["Geist"],
+              "display-lg": ["Geist"],
+            },
+            fontSize: {
+              "headline-lg-mobile": [
+                "24px",
+                { lineHeight: "32px", fontWeight: "600" },
+              ],
+              "title-md": ["20px", { lineHeight: "28px", fontWeight: "500" }],
+              "label-sm": [
+                "10px",
+                {
+                  lineHeight: "14px",
+                  letterSpacing: "0.05em",
+                  fontWeight: "500",
+                },
+              ],
+              "headline-lg": [
+                "32px",
+                { lineHeight: "40px", fontWeight: "600" },
+              ],
+              "body-sm": ["14px", { lineHeight: "20px", fontWeight: "400" }],
+              "label-md": [
+                "12px",
+                {
+                  lineHeight: "16px",
+                  letterSpacing: "0.05em",
+                  fontWeight: "500",
+                },
+              ],
+              "body-lg": ["16px", { lineHeight: "24px", fontWeight: "400" }],
+              "display-lg": [
+                "48px",
+                {
+                  lineHeight: "56px",
+                  letterSpacing: "-0.02em",
+                  fontWeight: "700",
+                },
+              ],
+            },
+          },
+        },
+      };
+    </script>
+    <style>
+      .material-symbols-outlined {
+        font-variation-settings:
+          "FILL" 0,
+          "wght" 400,
+          "GRAD" 0,
+          "opsz" 24;
+        display: inline-block;
+        vertical-align: middle;
+      }
+      .text-shadow-glow {
+        text-shadow: 0 0 12px rgba(0, 229, 255, 0.4);
+      }
+      .noise-overlay {
+        background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
+        opacity: 0.03;
+        pointer-events: none;
+      }
+      .profile-photo-wrap {
+        position: relative;
+        width: 100%;
+        padding-top: 125%;
+        overflow: hidden;
+        border-radius: 0.5rem;
+      }
+      .profile-photo-wrap img {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        object-position: center top;
+        display: block;
+      }
+    </style>
+  </head>
+  <body
+    class="bg-background text-on-background font-body-lg overflow-x-hidden selection:bg-primary-container selection:text-on-primary-container"
+  >
+    <div class="fixed inset-0 noise-overlay z-50"></div>
 
-					max-width: 280px;
-					margin: 0 auto;
-				}
-			}
-		</style>
-		<script src="assets/js/metrics.js"></script>
-	</head>
-	<body class="is-preload">
-		<!-- Google Tag Manager (noscript) -->
-		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-		<!-- End Google Tag Manager (noscript) -->
+    <!-- Navigation Header -->
+    <nav
+      class="bg-surface-container-lowest border-b border-outline-variant sticky top-0 z-[100] w-full"
+    >
+      <div
+        class="flex justify-between items-center px-lg py-md w-full max-w-7xl mx-auto"
+      >
+        <a
+          class="font-headline-lg text-headline-lg font-bold text-primary-fixed-dim tracking-tight"
+          href="index.html"
+          >Leigh Services</a
+        >
+        <div class="hidden md:flex items-center gap-lg">
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="index.html"
+            >Home</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="services.html"
+            >Services</a
+          >
+          <a
+            class="text-primary-fixed-dim font-bold border-b-2 border-primary-fixed-dim pb-1"
+            href="team.html"
+            >Meet the Team</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="certifications.html"
+            >Certifications</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="case-studies.html"
+            >Case Studies</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="testimonials.html"
+            >Testimonials</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="blog.html"
+            >Blog</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="contact.html"
+            >Contact</a
+          >
+          <a
+            class="ml-md bg-primary-container text-on-primary-fixed px-md py-sm rounded font-bold hover:opacity-80 transition-all"
+            href="contact.html"
+            >Consultation</a
+          >
+        </div>
+        <button
+          class="md:hidden text-primary-fixed-dim"
+          onclick="
+            document.getElementById('mobile-menu').classList.toggle('hidden')
+          "
+        >
+          <span class="material-symbols-outlined">menu</span>
+        </button>
+      </div>
+    </nav>
 
-		<!-- Header -->
-			<header id="header">
-				<a class="logo" href="index.html">Leigh Services</a>
-				<nav>
-					<a href="#menu">Menu</a>
-				</nav>
-			</header>
+    <!-- Mobile Menu -->
+    <div
+      class="hidden md:hidden fixed inset-0 z-[110] bg-surface-container-lowest p-lg"
+      id="mobile-menu"
+    >
+      <div class="flex flex-col gap-md">
+        <div class="flex justify-between items-center mb-xl">
+          <span
+            class="font-headline-lg-mobile text-headline-lg-mobile text-primary-fixed-dim"
+            >Leigh Services</span
+          >
+          <button
+            onclick="
+              document.getElementById('mobile-menu').classList.add('hidden')
+            "
+          >
+            <span class="material-symbols-outlined">close</span>
+          </button>
+        </div>
+        <a class="text-title-md py-sm" href="index.html">Home</a>
+        <a class="text-title-md py-sm" href="services.html">Services</a>
+        <a
+          class="text-title-md py-sm text-primary-fixed-dim font-bold"
+          href="team.html"
+          >Meet the Team</a
+        >
+        <a class="text-title-md py-sm" href="certifications.html"
+          >Certifications</a
+        >
+        <a class="text-title-md py-sm" href="case-studies.html">Case Studies</a>
+        <a class="text-title-md py-sm" href="testimonials.html">Testimonials</a>
+        <a class="text-title-md py-sm" href="blog.html">Blog</a>
+        <a class="text-title-md py-sm" href="contact.html">Contact</a>
+        <a
+          class="mt-md bg-primary-container text-on-primary-fixed text-center px-md py-md rounded font-bold"
+          href="contact.html"
+          >Consultation</a
+        >
+      </div>
+    </div>
 
-		<!-- Nav -->
-			<nav id="menu">
-				<ul class="links">
-					<li><a href="index.html">Home</a></li>
-					<li><a href="services.html">Services</a></li>
-					<li><a href="team.html">Meet the Team</a></li>
-					<li><a href="certifications.html">Certifications</a></li>
-					<li><a href="case-studies.html">Case Studies</a></li>
-					<li><a href="testimonials.html">Testimonials</a></li>
-					<li><a href="blog.html">Blog</a></li>
-					<li><a href="contact.html">Contact</a></li>
-				</ul>
-			</nav>
+    <main class="relative">
+      <!-- Hero -->
+      <section
+        class="relative py-xl md:py-24 border-b border-outline-variant overflow-hidden"
+      >
+        <div
+          class="max-w-7xl mx-auto px-lg relative z-10 text-center md:text-left"
+        >
+          <div
+            class="inline-flex items-center gap-xs px-sm py-xs bg-surface-container-high border border-outline-variant text-primary-fixed-dim mb-md"
+          >
+            <span class="material-symbols-outlined text-[16px]"
+              >engineering</span
+            >
+            <span class="font-label-md text-label-md"
+              >EXPERT LED CONSULTANCY</span
+            >
+          </div>
+          <h1
+            class="font-display-lg text-display-lg md:text-[64px] leading-tight mb-md text-primary max-w-4xl"
+          >
+            Meet the <span class="text-white">Founding Team.</span>
+          </h1>
+          <p class="text-body-lg text-on-surface-variant max-w-3xl">
+            Leigh Services was founded by Luke and Mark Leigh — two engineers
+            with a shared commitment to doing IT right: reliably, securely and
+            without unnecessary complexity. Between them they bring over 50
+            years of hands-on experience across infrastructure engineering,
+            PowerShell automation, data platform engineering and security
+            compliance.
+          </p>
+        </div>
+      </section>
 
-		<!-- Heading -->
-			<div id="heading">
-				<h1>Meet the Team</h1>
-			</div>
+      <!-- Team Profiles -->
+      <section class="py-xl md:py-32 bg-surface">
+        <div class="max-w-6xl mx-auto px-lg flex flex-col gap-xl">
+          <!-- Luke Leigh Card -->
+          <article
+            class="group bg-surface-container-low border border-outline-variant rounded-xl overflow-hidden hover:border-primary-fixed-dim/50 transition-all duration-300 p-md md:p-xl"
+          >
+            <!-- Hero row -->
+            <div class="flex flex-col md:flex-row gap-xl mb-xl">
+              <div class="w-full md:w-1/3 lg:w-1/4 flex-shrink-0">
+                <div class="profile-photo-wrap">
+                  <img alt="Luke Leigh" src="images/lukeleigh.jpg" />
+                </div>
+              </div>
+              <div class="flex-1 flex flex-col">
+                <div class="mb-md">
+                  <h2
+                    class="font-headline-lg text-headline-lg md:text-[40px] text-white mb-xs"
+                  >
+                    Luke Leigh
+                  </h2>
+                  <p
+                    class="font-label-md text-label-md text-primary-fixed-dim tracking-widest uppercase"
+                  >
+                    Infrastructure Engineer &amp; Owner
+                  </p>
+                </div>
+                <div
+                  class="text-body-lg text-on-surface-variant leading-relaxed space-y-md"
+                >
+                  <p>
+                    A dependable, diligent and analytical Infrastructure
+                    Engineer with expertise and in-depth knowledge of IT
+                    infrastructure and resolving support issues. Luke works well
+                    under pressure while keeping communication channels open, is
+                    quick to familiarise himself with the latest technology, and
+                    consistently delivers innovative solutions to complex
+                    problems.
+                  </p>
+                  <p>
+                    Currently serving as Infrastructure Engineer at Rail
+                    Delivery Group, Luke's primary focus is on-premises to
+                    Microsoft 365 migrations, system management and PowerShell
+                    automation. He has delivered infrastructure projects across
+                    retail, contact centres, financial services, cloud managed
+                    services and insurance — covering PCI DSS compliance
+                    programmes, virtualisation and Microsoft 365 deployments. He
+                    also publishes open-source PowerShell tooling on GitHub and
+                    the PowerShell Gallery.
+                  </p>
+                </div>
+                <div class="mt-lg flex flex-wrap gap-md">
+                  <a
+                    class="inline-flex items-center gap-xs text-on-surface-variant hover:text-primary-fixed-dim transition-colors font-label-md text-label-md uppercase tracking-wider"
+                    href="https://www.linkedin.com/in/lukeleigh"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <span class="material-symbols-outlined text-[18px]"
+                      >link</span
+                    >
+                    LinkedIn
+                  </a>
+                  <a
+                    class="inline-flex items-center gap-xs text-on-surface-variant hover:text-primary-fixed-dim transition-colors font-label-md text-label-md uppercase tracking-wider"
+                    href="https://github.com/BanterBoy"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <span class="material-symbols-outlined text-[18px]"
+                      >code</span
+                    >
+                    GitHub (BanterBoy)
+                  </a>
+                  <a
+                    class="inline-flex items-center gap-xs text-on-surface-variant hover:text-primary-fixed-dim transition-colors font-label-md text-label-md uppercase tracking-wider"
+                    href="https://blog.lukeleigh.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <span class="material-symbols-outlined text-[18px]"
+                      >article</span
+                    >
+                    Blog
+                  </a>
+                  <a
+                    class="inline-flex items-center gap-xs text-on-surface-variant hover:text-primary-fixed-dim transition-colors font-label-md text-label-md uppercase tracking-wider"
+                    href="https://www.powershellgallery.com/packages/PSCiscoMeraki"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <span class="material-symbols-outlined text-[18px]"
+                      >deployed_code</span
+                    >
+                    PowerShell Gallery
+                  </a>
+                </div>
+              </div>
+            </div>
 
-		<!-- Main -->
-			<section id="main" class="wrapper">
-				<div class="inner">
-					<div class="content">
+            <!-- Core Skills -->
+            <div class="border-t border-outline-variant pt-xl mb-xl">
+              <h3
+                class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-md"
+              >
+                Core Skills
+              </h3>
+              <div class="flex flex-wrap gap-xs">
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >PowerShell</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >Automation</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >Incident Management</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >Azure / Microsoft 365</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >VMware</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >On-prem / O365 Migration</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >PCI DSS</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >Exchange Online</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >Active Directory</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >Windows Server</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >Mimecast</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >Juniper</span
+                >
+              </div>
+            </div>
 
-						<header>
-							<h2>The People Behind Leigh Services</h2>
-							<p>Leigh Services was founded by Luke and Mark Leigh, two engineers with a shared commitment to doing IT right — reliably, securely and without unnecessary complexity. Between them they bring over 50 years of hands-on experience across infrastructure engineering, PowerShell automation, data platform engineering and security compliance.</p>
-						</header>
+            <!-- Experience Timeline -->
+            <div class="border-t border-outline-variant pt-xl">
+              <h3
+                class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-lg"
+              >
+                Experience
+              </h3>
+              <div class="flex flex-col">
+                <div class="py-md">
+                  <p
+                    class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-xs"
+                  >
+                    September 2022 – Present · London
+                  </p>
+                  <p
+                    class="font-title-md text-title-md text-white font-semibold mb-xs"
+                  >
+                    Infrastructure Engineer @ Rail Delivery Group
+                  </p>
+                  <p class="text-body-sm text-on-surface-variant">
+                    Recruited to assist in the transition to new premises and
+                    ongoing system management and maintenance.
+                  </p>
+                </div>
+                <div class="py-md border-t border-outline-variant">
+                  <p
+                    class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-xs"
+                  >
+                    September 2022 – Present
+                  </p>
+                  <p
+                    class="font-title-md text-title-md text-white font-semibold"
+                  >
+                    Infrastructure Engineer &amp; Owner @ Leigh IT Services Ltd
+                  </p>
+                </div>
+                <div class="py-md border-t border-outline-variant">
+                  <p
+                    class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-xs"
+                  >
+                    July 2021 – September 2022 · Purfleet
+                  </p>
+                  <p
+                    class="font-title-md text-title-md text-white font-semibold mb-xs"
+                  >
+                    Senior Infrastructure Engineer @ Carpetright
+                  </p>
+                  <p class="text-body-sm text-on-surface-variant">
+                    Managed and delivered project implementations. IT
+                    Infrastructure support for the group including messaging
+                    platforms, virtualisation, change management and Microsoft
+                    stack (on-premises and cloud).
+                  </p>
+                </div>
+                <div class="py-md border-t border-outline-variant">
+                  <p
+                    class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-xs"
+                  >
+                    November 2020 – February 2021
+                  </p>
+                  <p
+                    class="font-title-md text-title-md text-white font-semibold mb-xs"
+                  >
+                    Infrastructure Engineer @ Ventrica
+                  </p>
+                  <p class="text-body-sm text-on-surface-variant">
+                    PCI Compliance programme delivery: Juniper firewall
+                    upgrades, patch management, AD hardening, Exchange Server
+                    2013 security. Compliance achieved by December 31st
+                    deadline.
+                  </p>
+                </div>
+                <div class="py-md border-t border-outline-variant">
+                  <p
+                    class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-xs"
+                  >
+                    2018 – 2019 · London
+                  </p>
+                  <p
+                    class="font-title-md text-title-md text-white font-semibold mb-xs"
+                  >
+                    3rd Line Service Desk Technician @ Six Degrees Group
+                  </p>
+                  <p class="text-body-sm text-on-surface-variant">
+                    Complex incident resolution, change management, major
+                    incident management, mentoring and stakeholder
+                    communications across bespoke client infrastructures.
+                  </p>
+                </div>
+                <div class="py-md border-t border-outline-variant">
+                  <p
+                    class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-xs"
+                  >
+                    July 2018 – December 2018 · Southend-on-Sea
+                  </p>
+                  <p
+                    class="font-title-md text-title-md text-white font-semibold mb-xs"
+                  >
+                    Senior IT Administrator @ Solopress
+                  </p>
+                  <p class="text-body-sm text-on-surface-variant">
+                    Implemented Dell EMC + VMware 6.5 virtual environment,
+                    migrated from GFI Kerio Connect to Exchange 365, integrated
+                    with Azure Active Directory. Also built the PSCiscoMeraki
+                    PowerShell module as a personal development project during
+                    this period.
+                  </p>
+                </div>
+                <div class="py-md border-t border-outline-variant">
+                  <p
+                    class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-xs"
+                  >
+                    February 2017 – December 2017 · Upminster
+                  </p>
+                  <p
+                    class="font-title-md text-title-md text-white font-semibold mb-xs"
+                  >
+                    Infrastructure Engineer @ FSI Cloud
+                  </p>
+                  <p class="text-body-sm text-on-surface-variant">
+                    3rd line support for managed private cloud services.
+                    ISO9001/ISO27001 compliance, SIEM analysis, network
+                    performance optimisation, PowerShell automation
+                    architecture.
+                  </p>
+                </div>
+                <div class="py-md border-t border-outline-variant">
+                  <p
+                    class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-xs"
+                  >
+                    March 2008 – September 2016 · Southend-on-Sea &amp; Bristol
+                  </p>
+                  <p
+                    class="font-title-md text-title-md text-white font-semibold mb-xs"
+                  >
+                    Network Architect | Webmaster | PCI Compliance Specialist @
+                    Insure and Go Insurance Services
+                  </p>
+                  <p class="text-body-sm text-on-surface-variant">
+                    8+ year tenure owning the WAN infrastructure and PCI DSS
+                    compliance programme. Delivered WAN amalgamation across four
+                    offices, Mapfre Global WAN integration, full virtualisation
+                    and data centre migration to Wales.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </article>
 
-						<!-- Luke -->
-						<div class="profile-section">
-							<div class="profile-photo">
-							<div class="photo-wrap">
-								<img src="images/lukeleigh.jpg" alt="Luke Leigh" />
-							</div>
-								<div class="photo-meta">
-									<a href="https://www.linkedin.com/in/lukeleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>LinkedIn</a>
-									<a href="https://github.com/BanterBoy" target="_blank" rel="noopener noreferrer"><i class="icon fa-github">&nbsp;</i>GitHub (BanterBoy)</a>
-									<a href="https://blog.lukeleigh.com" target="_blank" rel="noopener noreferrer"><i class="icon fa-rss">&nbsp;</i>Blog</a>
-									<a href="https://www.powershellgallery.com/packages/PSCiscoMeraki" target="_blank" rel="noopener noreferrer"><i class="icon fa-cube">&nbsp;</i>PowerShell Gallery</a>
-								</div>
-							</div>
-							<div class="profile-body">
-								<h2>Luke Leigh</h2>
-								<p class="profile-role">Infrastructure Engineer &amp; Owner</p>
-								<p>A dependable, diligent and analytical Infrastructure Engineer with expertise and in-depth knowledge of IT infrastructure and resolving support issues. Luke works well under pressure while keeping communication channels open, is quick to familiarise himself with the latest technology, and consistently delivers innovative solutions to complex problems.</p>
-								<p>Currently serving as Infrastructure Engineer at Rail Delivery Group, Luke's primary focus is on-premises to Microsoft 365 migrations, system management and PowerShell automation. He has delivered infrastructure projects across retail, contact centres, financial services, cloud managed services and insurance — covering PCI DSS compliance programmes, virtualisation and Microsoft 365 deployments. He also publishes open-source PowerShell tooling on GitHub and the PowerShell Gallery.</p>
+          <!-- Mark Leigh Card -->
+          <article
+            class="group bg-surface-container-low border border-outline-variant rounded-xl overflow-hidden hover:border-primary-fixed-dim/50 transition-all duration-300 p-md md:p-xl"
+          >
+            <!-- Hero row -->
+            <div class="flex flex-col md:flex-row gap-xl mb-xl">
+              <div class="w-full md:w-1/3 lg:w-1/4 flex-shrink-0">
+                <div class="profile-photo-wrap">
+                  <img alt="Mark Leigh" src="images/markleigh.jpg" />
+                </div>
+              </div>
+              <div class="flex-1 flex flex-col">
+                <div class="mb-md">
+                  <h2
+                    class="font-headline-lg text-headline-lg md:text-[40px] text-white mb-xs"
+                  >
+                    Mark Leigh
+                  </h2>
+                  <p
+                    class="font-label-md text-label-md text-primary-fixed-dim tracking-widest uppercase"
+                  >
+                    Senior Data Engineer &amp; Security Specialist
+                  </p>
+                </div>
+                <div
+                  class="text-body-lg text-on-surface-variant leading-relaxed space-y-md"
+                >
+                  <p>
+                    A senior data engineer focused on improving the integrity,
+                    reliability and security of data platforms. Most of Mark's
+                    work starts when something isn't quite right — data that
+                    can't be trusted, pipelines that aren't behaving as
+                    expected, or systems risk that isn't fully understood. He's
+                    skilled at cutting through the noise to identify what's
+                    actually going wrong beneath the surface, and putting in
+                    place solutions that make things stable, predictable and
+                    safe.
+                  </p>
+                  <p>
+                    CompTIA Security+ certified with CREST CPSA ongoing, Mark
+                    has naturally moved closer to DevSecOps and cyber-focused
+                    practices — not as a separate discipline, but as part of how
+                    platforms should be built and run, with security, control
+                    and risk considered from the outset. His most notable
+                    delivery: leading a legacy SAS-to-Google Cloud Platform
+                    migration at Swarovski within 9 months, enabling €1m in
+                    annual cost savings.
+                  </p>
+                </div>
+                <div class="mt-lg flex flex-wrap gap-md">
+                  <a
+                    class="inline-flex items-center gap-xs text-on-surface-variant hover:text-primary-fixed-dim transition-colors font-label-md text-label-md uppercase tracking-wider"
+                    href="https://www.linkedin.com/in/markleigh"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <span class="material-symbols-outlined text-[18px]"
+                      >link</span
+                    >
+                    LinkedIn
+                  </a>
+                </div>
+              </div>
+            </div>
 
-								<h4>Core Skills</h4>
-								<div class="skill-tags">
-									<span class="skill-tag">PowerShell</span>
-									<span class="skill-tag">Automation</span>
-									<span class="skill-tag">Incident Management</span>
-									<span class="skill-tag">Azure / Microsoft 365</span>
-									<span class="skill-tag">VMware</span>
-									<span class="skill-tag">On-prem / O365 Migration</span>
-									<span class="skill-tag">PCI DSS</span>
-									<span class="skill-tag">Exchange Online</span>
-									<span class="skill-tag">Active Directory</span>
-									<span class="skill-tag">Windows Server</span>
-									<span class="skill-tag">Mimecast</span>
-									<span class="skill-tag">Juniper</span>
-								</div>
+            <!-- Core Skills -->
+            <div class="border-t border-outline-variant pt-xl mb-xl">
+              <h3
+                class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-md"
+              >
+                Core Skills
+              </h3>
+              <div class="flex flex-wrap gap-xs">
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >Data Engineering</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >DevSecOps</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >Python</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >SQL</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >SAS</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >GCP</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >Data Pipeline Security</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >Data Integrity &amp; Lineage</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >Root Cause Analysis</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >Governance &amp; Compliance</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >CompTIA Security+</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >CREST CPSA</span
+                >
+              </div>
+            </div>
 
-								<h4>Experience</h4>
+            <!-- Certifications -->
+            <div class="border-t border-outline-variant pt-xl mb-xl">
+              <h3
+                class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-md"
+              >
+                Certifications
+              </h3>
+              <div class="flex flex-wrap gap-xs">
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >CompTIA Security+ — Optima Training (2026)</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >CREST CPSA — Optima Training (ongoing)</span
+                >
+                <span
+                  class="bg-surface-container-high border border-outline-variant rounded-lg px-3 py-1 text-label-sm font-label-sm text-primary-fixed-dim"
+                  >BSc Applied Computer Science — De Montfort University</span
+                >
+              </div>
+            </div>
 
-								<div class="exp-item">
-									<strong>Rail Delivery Group — Infrastructure Engineer</strong>
-									<span>September 2022 – Present &middot; London</span>
-									<p>Recruited to assist in the transition to new premises and ongoing system management and maintenance.</p>
-								</div>
-								<div class="exp-item">
-									<strong>Leigh IT Services Ltd — Infrastructure Engineer &amp; Owner</strong>
-									<span>September 2022 – Present</span>
-								</div>
-								<div class="exp-item">
-									<strong>Carpetright — Senior Infrastructure Engineer</strong>
-									<span>July 2021 – September 2022 &middot; Purfleet</span>
-									<p>Managed and delivered project implementations. IT Infrastructure support for the group including messaging platforms, virtualisation, change management and Microsoft stack (on-premises and cloud).</p>
-								</div>
-								<div class="exp-item">
-									<strong>Ventrica — Infrastructure Engineer</strong>
-									<span>November 2020 – February 2021</span>
-									<p>PCI Compliance programme delivery: Juniper firewall upgrades, patch management, AD hardening, Exchange Server 2013 security. Compliance achieved by December 31st deadline.</p>
-								</div>
-								<div class="exp-item">
-									<strong>Six Degrees Group — 3rd Line Service Desk Technician</strong>
-									<span>2018 – 2019 &middot; London</span>
-									<p>Complex incident resolution, change management, major incident management, mentoring and stakeholder communications across bespoke client infrastructures.</p>
-								</div>
-								<div class="exp-item">
-									<strong>Solopress — Senior IT Administrator</strong>
-									<span>July 2018 – December 2018 &middot; Southend-on-Sea</span>
-									<p>Implemented Dell EMC + VMware 6.5 virtual environment, migrated from GFI Kerio Connect to Exchange 365, integrated with Azure Active Directory. Also built the PSCiscoMeraki PowerShell module as a personal development project during this period.</p>
-								</div>
-								<div class="exp-item">
-									<strong>FSI Cloud — Infrastructure Engineer</strong>
-									<span>February 2017 – December 2017 &middot; Upminster</span>
-									<p>3rd line support for managed private cloud services. ISO9001/ISO27001 compliance, SIEM analysis, network performance optimisation, PowerShell automation architecture.</p>
-								</div>
-								<div class="exp-item">
-									<strong>Insure and Go Insurance Services — Network Architect | Webmaster | PCI Compliance Specialist</strong>
-									<span>March 2008 – September 2016 &middot; Southend-on-Sea &amp; Bristol</span>
-									<p>8+ year tenure owning the WAN infrastructure and PCI DSS compliance programme. Delivered WAN amalgamation across four offices, Mapfre Global WAN integration, full virtualisation and data centre migration to Wales.</p>
-								</div>
-							</div>
-						</div>
+            <!-- Experience Timeline -->
+            <div class="border-t border-outline-variant pt-xl">
+              <h3
+                class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-lg"
+              >
+                Experience
+              </h3>
+              <div class="flex flex-col">
+                <div class="py-md">
+                  <p
+                    class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-xs"
+                  >
+                    March 2020 – January 2024 · Zurich
+                  </p>
+                  <p
+                    class="font-title-md text-title-md text-white font-semibold mb-xs"
+                  >
+                    Senior Data Engineer @ Swarovski
+                  </p>
+                  <p class="text-body-sm text-on-surface-variant">
+                    Initially contracted to stabilise a poorly performing,
+                    undocumented SAS analytics environment; transitioned into a
+                    permanent role as the most senior engineer on the Data Lake
+                    team. Led the migration of a complex SAS platform to GCP in
+                    9 months, enabling €1m in annual savings. Reduced failure
+                    rates from ~25% to 2% and cut processing time by over 50%.
+                  </p>
+                </div>
+                <div class="py-md border-t border-outline-variant">
+                  <p
+                    class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-xs"
+                  >
+                    January 2016 – September 2019 · Halifax
+                  </p>
+                  <p
+                    class="font-title-md text-title-md text-white font-semibold mb-xs"
+                  >
+                    SAS Consultant, Lead Developer (FINREP) @ Lloyds Banking
+                    Group
+                  </p>
+                  <p class="text-body-sm text-on-surface-variant">
+                    Lead developer on a regulatory reporting programme, bridging
+                    project management and development to deliver a complex
+                    FINREP solution. Key contributor to a Collections &amp;
+                    Recoveries migration applying Agile principles within a
+                    Waterfall environment.
+                  </p>
+                </div>
+                <div class="py-md border-t border-outline-variant">
+                  <p
+                    class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-xs"
+                  >
+                    September 2014 – December 2015 · West Midlands
+                  </p>
+                  <p
+                    class="font-title-md text-title-md text-white font-semibold mb-xs"
+                  >
+                    SAS Consultant @ RWE Npower
+                  </p>
+                  <p class="text-body-sm text-on-surface-variant">
+                    Delivered data extraction and transformation solutions for
+                    targeted marketing campaigns. Secured stakeholder buy-in to
+                    improve data quality and consistency, reducing rework.
+                    Mentored team members on SAS Enterprise Guide.
+                  </p>
+                </div>
+                <div class="py-md border-t border-outline-variant">
+                  <p
+                    class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-xs"
+                  >
+                    January 2014 – May 2014 · Pendeford
+                  </p>
+                  <p
+                    class="font-title-md text-title-md text-white font-semibold mb-xs"
+                  >
+                    SAS Consultant, MMR @ Lloyds Banking Group
+                  </p>
+                  <p class="text-body-sm text-on-surface-variant">
+                    Supported delivery of regulatory change under the Mortgage
+                    Market Review, developing and testing data solutions within
+                    a controlled banking environment.
+                  </p>
+                </div>
+                <div class="py-md border-t border-outline-variant">
+                  <p
+                    class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-xs"
+                  >
+                    April 2001 – May 2007
+                  </p>
+                  <p
+                    class="font-title-md text-title-md text-white font-semibold"
+                  >
+                    Senior Systems Analyst @ Royal Bank of Scotland
+                  </p>
+                </div>
+                <div class="py-md border-t border-outline-variant">
+                  <p
+                    class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-xs"
+                  >
+                    Earlier Roles
+                  </p>
+                  <p
+                    class="font-title-md text-title-md text-white font-semibold"
+                  >
+                    Barclaycard · Capgemini · Nationwide Building Society · CSC
+                    Sverige AB · Direct Line
+                  </p>
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
 
-						<!-- Mark -->
-						<div class="profile-section">
-							<div class="profile-photo">
-							<div class="photo-wrap">
-								<img src="images/markleigh.jpg" alt="Mark Leigh" />
-							</div>
-								<div class="photo-meta">
-									<a href="https://www.linkedin.com/in/markleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>LinkedIn</a>
-								</div>
-							</div>
-							<div class="profile-body">
-								<h2>Mark Leigh</h2>
-								<p class="profile-role">Senior Data Engineer &amp; Security Specialist</p>
-								<p>A senior data engineer focused on improving the integrity, reliability and security of data platforms. Most of Mark's work starts when something isn't quite right — data that can't be trusted, pipelines that aren't behaving as expected, or systems risk that isn't fully understood. He's skilled at cutting through the noise to identify what's actually going wrong beneath the surface, and putting in place solutions that make things stable, predictable and safe.</p>
-								<p>CompTIA Security+ certified with CREST CPSA ongoing, Mark has naturally moved closer to DevSecOps and cyber-focused practices — not as a separate discipline, but as part of how platforms should be built and run, with security, control and risk considered from the outset. His most notable delivery: leading a legacy SAS-to-Google Cloud Platform migration at Swarovski within 9 months, enabling &euro;1m in annual cost savings.</p>
+      <!-- Credentials / Stats Strip -->
+      <section
+        class="py-xl bg-surface-container-lowest border-y border-outline-variant"
+      >
+        <div class="max-w-7xl mx-auto px-lg">
+          <div class="grid grid-cols-2 md:grid-cols-4 gap-lg text-center">
+            <div>
+              <div
+                class="font-display-lg text-display-lg text-primary-fixed-dim mb-xs"
+              >
+                50+
+              </div>
+              <p class="font-label-md text-label-md text-on-surface-variant">
+                YEARS EXPERIENCE
+              </p>
+            </div>
+            <div>
+              <div
+                class="font-display-lg text-display-lg text-primary-fixed-dim mb-xs"
+              >
+                €1M
+              </div>
+              <p class="font-label-md text-label-md text-on-surface-variant">
+                CLIENT SAVINGS
+              </p>
+            </div>
+            <div>
+              <div
+                class="font-display-lg text-display-lg text-primary-fixed-dim mb-xs"
+              >
+                100+
+              </div>
+              <p class="font-label-md text-label-md text-on-surface-variant">
+                AUTOMATION TOOLS
+              </p>
+            </div>
+            <div>
+              <div
+                class="font-display-lg text-display-lg text-primary-fixed-dim mb-xs"
+              >
+                Sec+
+              </div>
+              <p class="font-label-md text-label-md text-on-surface-variant">
+                CERTIFIED EXPERTS
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
 
-								<h4>Core Skills</h4>
-								<div class="skill-tags">
-									<span class="skill-tag">Data Engineering</span>
-									<span class="skill-tag">DevSecOps</span>
-									<span class="skill-tag">Python</span>
-									<span class="skill-tag">SQL</span>
-									<span class="skill-tag">SAS (Base / Macro / DI Studio)</span>
-									<span class="skill-tag">Google Cloud Platform</span>
-									<span class="skill-tag">Data Pipeline Security</span>
-									<span class="skill-tag">Data Integrity &amp; Lineage</span>
-									<span class="skill-tag">Root Cause Analysis</span>
-									<span class="skill-tag">Governance &amp; Compliance</span>
-									<span class="skill-tag">CompTIA Security+</span>
-									<span class="skill-tag">CREST CPSA</span>
-								</div>
+      <!-- CTA -->
+      <section class="py-32 relative overflow-hidden">
+        <div class="absolute inset-0 bg-primary-container/5"></div>
+        <div class="max-w-3xl mx-auto px-lg text-center relative z-10">
+          <h2
+            class="font-headline-lg text-headline-lg md:text-[48px] text-white mb-md"
+          >
+            Ready to work with the experts?
+          </h2>
+          <p class="text-body-lg text-on-surface-variant mb-xl">
+            Whether you need infrastructure support, automation tooling, data
+            platform engineering or compliance guidance — we bring the expertise
+            to get the job done.
+          </p>
+          <div class="flex flex-col md:flex-row gap-md justify-center">
+            <a
+              class="px-xl py-md bg-primary-container text-on-primary-fixed font-bold rounded-lg hover:brightness-110 transition-all shadow-lg shadow-primary-container/20"
+              href="contact.html"
+              >Get in Touch</a
+            >
+            <a
+              class="px-xl py-md border border-outline text-white font-bold rounded-lg hover:bg-white/10 transition-all"
+              href="services.html"
+              >View Our Services</a
+            >
+          </div>
+        </div>
+      </section>
+    </main>
 
-								<h4>Certifications</h4>
-								<div class="skill-tags">
-									<span class="skill-tag">BSc Applied Computer Science — De Montfort University</span>
-									<span class="skill-tag">CompTIA Security+ — Optima Training (2026)</span>
-									<span class="skill-tag">CREST CPSA — Optima Training (ongoing)</span>
-								</div>
+    <!-- Footer -->
+    <footer class="bg-surface-container-lowest border-t border-outline-variant">
+      <div
+        class="grid grid-cols-1 md:grid-cols-4 gap-xl px-lg py-xl max-w-7xl mx-auto"
+      >
+        <div class="col-span-1 md:col-span-1">
+          <div
+            class="font-title-md text-title-md font-bold text-primary-fixed-dim mb-md"
+          >
+            Leigh Services
+          </div>
+          <p
+            class="font-body-sm text-body-sm text-on-surface-variant leading-relaxed"
+          >
+            Expert IT Infrastructure, Automation and Data Engineering consulting
+            based in Southend-on-Sea, Essex.
+          </p>
+          <p
+            class="font-body-sm text-body-sm text-on-surface-variant mt-md italic"
+          >
+            63 Archer Avenue, Southend on Sea, Essex SS2 4QU
+          </p>
+        </div>
+        <div>
+          <div
+            class="font-label-md text-label-md text-primary-fixed-dim mb-md uppercase tracking-wider"
+          >
+            Quick Links
+          </div>
+          <div class="flex flex-col gap-sm">
+            <a
+              class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+              href="index.html"
+              >Home</a
+            >
+            <a
+              class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+              href="services.html"
+              >Services</a
+            >
+            <a
+              class="font-body-sm text-body-sm text-primary-fixed-dim font-bold"
+              href="team.html"
+              >Meet the Team</a
+            >
+            <a
+              class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+              href="certifications.html"
+              >Certifications</a
+            >
+          </div>
+        </div>
+        <div>
+          <div
+            class="font-label-md text-label-md text-primary-fixed-dim mb-md uppercase tracking-wider"
+          >
+            Connect
+          </div>
+          <div class="flex flex-col gap-sm">
+            <a
+              class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors inline-flex items-center gap-xs"
+              href="https://www.linkedin.com/in/lukeleigh"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="material-symbols-outlined text-sm">link</span> Luke
+              on LinkedIn
+            </a>
+            <a
+              class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors inline-flex items-center gap-xs"
+              href="https://www.linkedin.com/in/markleigh"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="material-symbols-outlined text-sm">link</span> Mark
+              on LinkedIn
+            </a>
+            <a
+              class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors inline-flex items-center gap-xs"
+              href="https://github.com/BanterBoy"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="material-symbols-outlined text-sm">code</span> GitHub
+            </a>
+          </div>
+        </div>
+        <div>
+          <div
+            class="font-label-md text-label-md text-primary-fixed-dim mb-md uppercase tracking-wider"
+          >
+            Legal
+          </div>
+          <p class="font-body-sm text-body-sm text-on-surface-variant mb-md">
+            © 2024–2026 Leigh IT Services Ltd. All rights reserved.
+          </p>
+          <div class="flex gap-md">
+            <span class="material-symbols-outlined text-outline-variant"
+              >verified_user</span
+            >
+            <span class="material-symbols-outlined text-outline-variant"
+              >shield</span
+            >
+          </div>
+        </div>
+      </div>
+    </footer>
 
-								<h4>Experience</h4>
-
-								<div class="exp-item">
-									<strong>SWAROVSKI — Senior Data Engineer</strong>
-									<span>March 2020 – January 2024 &middot; Zurich</span>
-									<p>Initially contracted to stabilise a poorly performing, undocumented SAS analytics environment; transitioned into a permanent role as the most senior engineer on the Data Lake team. Led the migration of a complex SAS platform to GCP in 9 months, enabling &euro;1m in annual savings. Reduced failure rates from ~25% to 2% and cut processing time by over 50%.</p>
-								</div>
-								<div class="exp-item">
-									<strong>Lloyds Banking Group — SAS Consultant, Lead Developer (FINREP)</strong>
-									<span>January 2016 – September 2019 &middot; Halifax</span>
-									<p>Lead developer on a regulatory reporting programme, bridging project management and development to deliver a complex FINREP solution. Key contributor to a Collections &amp; Recoveries migration applying Agile principles within a Waterfall environment.</p>
-								</div>
-								<div class="exp-item">
-									<strong>RWE Npower — SAS Consultant</strong>
-									<span>September 2014 – December 2015 &middot; West Midlands</span>
-									<p>Delivered data extraction and transformation solutions for targeted marketing campaigns. Secured stakeholder buy-in to improve data quality and consistency, reducing rework. Mentored team members on SAS Enterprise Guide.</p>
-								</div>
-								<div class="exp-item">
-									<strong>Lloyds Banking Group — SAS Consultant, MMR</strong>
-									<span>January 2014 – May 2014 &middot; Pendeford</span>
-									<p>Supported delivery of regulatory change under the Mortgage Market Review, developing and testing data solutions within a controlled banking environment.</p>
-								</div>
-								<div class="exp-item">
-									<strong>Royal Bank of Scotland — Senior Systems Analyst</strong>
-									<span>April 2001 – May 2007</span>
-								</div>
-								<div class="exp-item">
-									<strong>Earlier roles</strong>
-									<span>Barclaycard, Capgemini, Nationwide Building Society, CSC Sverige AB, Direct Line</span>
-								</div>
-							</div>
-						</div>
-
-					</div>
-				</div>
-			</section>
-
-		<!-- Footer -->
-			<footer id="footer">
-				<div class="inner">
-					<div class="content">
-						<section>
-							<h3>Leigh Services</h3>
-							<p>Expert IT Infrastructure, Automation and Data Engineering consulting based in Southend-on-Sea, Essex. Serving clients across the UK and internationally.</p>
-						<p>63 Archer Avenue, Southend on Sea, Essex SS2 4QU</p>
-						</section>
-						<section>
-							<h4>Services</h4>
-							<ul class="alt">
-							<li><a href="services.html#it-infrastructure">IT Infrastructure</a></li>
-							<li><a href="services.html#powershell-automation">PowerShell &amp; Automation</a></li>
-							<li><a href="services.html#cloud-solutions">Cloud Solutions</a></li>
-							<li><a href="services.html#data-engineering">Data Engineering</a></li>
-							<li><a href="services.html#security-compliance">Security &amp; Compliance</a></li>
-							<li><a href="services.html#devsecops">DevSecOps</a></li>
-							</ul>
-						</section>
-						<section>
-							<h4>Connect</h4>
-							<ul class="plain">
-								<li><a href="https://www.linkedin.com/in/lukeleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>Luke on LinkedIn</a></li>
-								<li><a href="https://www.linkedin.com/in/markleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>Mark on LinkedIn</a></li>
-								<li><a href="https://github.com/BanterBoy" target="_blank" rel="noopener noreferrer"><i class="icon fa-github">&nbsp;</i>GitHub (BanterBoy)</a></li>
-								<li><a href="https://blog.lukeleigh.com" target="_blank" rel="noopener noreferrer"><i class="icon fa-rss">&nbsp;</i>Luke's Blog</a></li>
-							</ul>
-						</section>
-					</div>
-					<div class="copyright">
-					&copy; 2024&ndash;2026 Leigh IT Services Ltd. All rights reserved.
-					</div>
-				</div>
-			</footer>
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
-
-	</body>
+    <script>
+      // Mobile menu close on link click
+      document.querySelectorAll("#mobile-menu a").forEach((link) => {
+        link.addEventListener("click", () => {
+          document.getElementById("mobile-menu").classList.add("hidden");
+        });
+      });
+    </script>
+  </body>
 </html>

--- a/testimonials.html
+++ b/testimonials.html
@@ -1,221 +1,1116 @@
-<!DOCTYPE HTML>
-<html lang="en-gb">
-	<head>
-		<title>Testimonials | Leigh Services</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<meta name="description" content="What clients say about Leigh Services — recommendations from LinkedIn covering IT infrastructure, PCI compliance, data engineering and more." />
-		<meta name="keywords" content="Leigh Services testimonials, client recommendations, IT infrastructure, PCI DSS, data engineering" />
-		<meta property="og:title" content="Testimonials | Leigh Services" />
-		<meta property="og:description" content="Recommendations from clients on infrastructure delivery, PCI compliance, data engineering and PowerShell automation." />
-		<meta property="og:url" content="https://leigh-services.com/testimonials.html" />
-		<meta property="og:image" content="https://leigh-services.com/images/banner.jpg" />
-		<meta property="og:type" content="website" />
-		<meta property="og:site_name" content="Leigh Services" />
-		<meta http-equiv="content-language" content="en-gb" />
-		<link rel="canonical" href="https://leigh-services.com/testimonials.html" />
-		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Testimonials | Leigh Services" />
-		<meta name="twitter:description" content="Recommendations from clients on infrastructure delivery, PCI compliance, data engineering and PowerShell automation." />
-		<meta name="twitter:image" content="https://leigh-services.com/images/banner.jpg" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<script src="assets/js/metrics.js"></script>
-	</head>
-	<body class="is-preload">
-		<!-- Google Tag Manager (noscript) -->
-		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-		<!-- End Google Tag Manager (noscript) -->
+<!doctype html>
+<html class="dark" lang="en-gb">
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Testimonials | Leigh Services</title>
+    <meta
+      name="description"
+      content="What clients say about Leigh Services — recommendations from LinkedIn covering IT infrastructure, PCI compliance, data engineering and more."
+    />
+    <meta
+      name="keywords"
+      content="Leigh Services testimonials, client recommendations, IT infrastructure, PCI DSS, data engineering"
+    />
+    <meta property="og:title" content="Testimonials | Leigh Services" />
+    <meta
+      property="og:description"
+      content="Recommendations from clients on infrastructure delivery, PCI compliance, data engineering and PowerShell automation."
+    />
+    <meta
+      property="og:url"
+      content="https://leigh-services.com/testimonials.html"
+    />
+    <meta
+      property="og:image"
+      content="https://leigh-services.com/images/banner.jpg"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Leigh Services" />
+    <meta http-equiv="content-language" content="en-gb" />
+    <link rel="canonical" href="https://leigh-services.com/testimonials.html" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Testimonials | Leigh Services" />
+    <meta
+      name="twitter:description"
+      content="Recommendations from clients on infrastructure delivery, PCI compliance, data engineering and PowerShell automation."
+    />
+    <meta
+      name="twitter:image"
+      content="https://leigh-services.com/images/banner.jpg"
+    />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&amp;family=JetBrains+Mono:wght@100..800&amp;display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
+      rel="stylesheet"
+    />
+    <script src="assets/js/metrics.js"></script>
+    <script id="tailwind-config">
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            colors: {
+              "surface-container-low": "#131c2b",
+              "outline-variant": "#3b494c",
+              "surface-container-lowest": "#060e1d",
+              "on-background": "#dbe2f8",
+              "surface-tint": "#00daf3",
+              "primary-container": "#00e5ff",
+              "surface-container": "#18202f",
+              surface: "#0b1323",
+              "on-primary-container": "#00626e",
+              "surface-container-high": "#222a3a",
+              "primary-fixed-dim": "#00daf3",
+              primary: "#c3f5ff",
+              background: "#0b1323",
+              "on-primary-fixed": "#001f24",
+              "inverse-on-surface": "#283041",
+              "surface-variant": "#2d3546",
+              "surface-container-highest": "#2d3546",
+              outline: "#849396",
+              "on-surface-variant": "#bac9cc",
+              "surface-bright": "#31394a",
+              "primary-fixed": "#9cf0ff",
+              "surface-dim": "#0b1323",
+              "on-surface": "#dbe2f8",
+            },
+            borderRadius: {
+              DEFAULT: "0.125rem",
+              lg: "0.25rem",
+              xl: "0.5rem",
+              full: "0.75rem",
+            },
+            spacing: {
+              xs: "4px",
+              margin: "24px",
+              lg: "24px",
+              xl: "40px",
+              gutter: "16px",
+              base: "4px",
+              sm: "8px",
+              md: "16px",
+            },
+            fontFamily: {
+              "headline-lg-mobile": ["Geist"],
+              "title-md": ["Geist"],
+              "label-sm": ["JetBrains Mono"],
+              "headline-lg": ["Geist"],
+              "body-sm": ["Geist"],
+              "label-md": ["JetBrains Mono"],
+              "body-lg": ["Geist"],
+              "display-lg": ["Geist"],
+            },
+            fontSize: {
+              "headline-lg-mobile": [
+                "24px",
+                { lineHeight: "32px", fontWeight: "600" },
+              ],
+              "title-md": ["20px", { lineHeight: "28px", fontWeight: "500" }],
+              "label-sm": [
+                "10px",
+                {
+                  lineHeight: "14px",
+                  letterSpacing: "0.05em",
+                  fontWeight: "500",
+                },
+              ],
+              "headline-lg": [
+                "32px",
+                { lineHeight: "40px", fontWeight: "600" },
+              ],
+              "body-sm": ["14px", { lineHeight: "20px", fontWeight: "400" }],
+              "label-md": [
+                "12px",
+                {
+                  lineHeight: "16px",
+                  letterSpacing: "0.05em",
+                  fontWeight: "500",
+                },
+              ],
+              "body-lg": ["16px", { lineHeight: "24px", fontWeight: "400" }],
+              "display-lg": [
+                "48px",
+                {
+                  lineHeight: "56px",
+                  letterSpacing: "-0.02em",
+                  fontWeight: "700",
+                },
+              ],
+            },
+          },
+        },
+      };
+    </script>
+    <style>
+      .material-symbols-outlined {
+        font-variation-settings:
+          "FILL" 0,
+          "wght" 400,
+          "GRAD" 0,
+          "opsz" 24;
+        display: inline-block;
+        vertical-align: middle;
+      }
+      body {
+        background-color: #0b1323;
+        color: #dbe2f8;
+        font-family: "Geist", sans-serif;
+      }
+      .bento-grid {
+        display: grid;
+        grid-template-columns: repeat(12, 1fr);
+        gap: 16px;
+      }
+      .glass-card {
+        background: rgba(24, 32, 47, 0.7);
+        backdrop-filter: blur(12px);
+        border: 1px solid rgba(132, 147, 150, 0.1);
+        transition:
+          box-shadow 0.3s,
+          border-color 0.3s;
+      }
+      .glow-hover:hover {
+        box-shadow: 0 0 20px rgba(0, 229, 255, 0.15);
+        border-color: rgba(0, 229, 255, 0.3);
+      }
+      .testimonial-stripe {
+        position: absolute;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        width: 2px;
+        background-color: #00e5ff;
+      }
+      .avatar-initials {
+        font-family: "JetBrains Mono", monospace;
+        font-weight: 600;
+        letter-spacing: 0.05em;
+      }
+    </style>
+  </head>
+  <body
+    class="selection:bg-primary-container selection:text-on-primary-container"
+  >
+    <!-- Google Tag Manager (noscript) -->
+    <noscript
+      ><iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-5NBQFP8F"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden"
+      ></iframe
+    ></noscript>
 
-		<!-- Header -->
-			<header id="header">
-				<a class="logo" href="index.html">Leigh Services</a>
-				<nav>
-					<a href="#menu">Menu</a>
-				</nav>
-			</header>
+    <!-- Navigation Header -->
+    <header
+      class="bg-surface-container-lowest border-b border-outline-variant fixed top-0 w-full z-[100]"
+    >
+      <nav
+        class="flex justify-between items-center px-lg py-md w-full max-w-7xl mx-auto"
+      >
+        <a
+          class="font-headline-lg text-headline-lg font-bold text-primary-fixed-dim tracking-tight"
+          href="index.html"
+          >Leigh Services</a
+        >
+        <div class="hidden md:flex items-center gap-lg">
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="index.html"
+            >Home</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="services.html"
+            >Services</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="team.html"
+            >Meet the Team</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="certifications.html"
+            >Certifications</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="case-studies.html"
+            >Case Studies</a
+          >
+          <a
+            class="text-primary-fixed-dim font-bold border-b-2 border-primary-fixed-dim pb-1"
+            href="testimonials.html"
+            >Testimonials</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="blog.html"
+            >Blog</a
+          >
+          <a
+            class="text-on-surface-variant font-medium hover:text-primary transition-colors duration-200"
+            href="contact.html"
+            >Contact</a
+          >
+          <a
+            class="ml-md bg-primary-container text-on-primary-container px-md py-sm rounded-lg font-bold hover:opacity-80 transition-all"
+            href="contact.html"
+            >Consultation</a
+          >
+        </div>
+        <button
+          class="md:hidden text-primary-fixed-dim"
+          onclick="
+            document.getElementById('mobile-menu').classList.toggle('hidden')
+          "
+          aria-label="Open menu"
+        >
+          <span class="material-symbols-outlined">menu</span>
+        </button>
+      </nav>
+    </header>
 
-		<!-- Nav -->
-			<nav id="menu">
-				<ul class="links">
-					<li><a href="index.html">Home</a></li>
-					<li><a href="services.html">Services</a></li>
-					<li><a href="team.html">Meet the Team</a></li>
-					<li><a href="certifications.html">Certifications</a></li>
-					<li><a href="case-studies.html">Case Studies</a></li>
-					<li><a href="testimonials.html">Testimonials</a></li>
-					<li><a href="blog.html">Blog</a></li>
-					<li><a href="contact.html">Contact</a></li>
-				</ul>
-			</nav>
+    <!-- Mobile Menu -->
+    <div
+      class="hidden md:hidden fixed inset-0 z-[110] bg-surface-container-lowest p-lg"
+      id="mobile-menu"
+    >
+      <div class="flex flex-col gap-md">
+        <div class="flex justify-between items-center mb-xl">
+          <span
+            class="font-headline-lg-mobile text-headline-lg-mobile text-primary-fixed-dim"
+            >Leigh Services</span
+          >
+          <button
+            onclick="
+              document.getElementById('mobile-menu').classList.add('hidden')
+            "
+            aria-label="Close menu"
+          >
+            <span class="material-symbols-outlined">close</span>
+          </button>
+        </div>
+        <a class="text-title-md py-sm" href="index.html">Home</a>
+        <a class="text-title-md py-sm" href="services.html">Services</a>
+        <a class="text-title-md py-sm" href="team.html">Meet the Team</a>
+        <a class="text-title-md py-sm" href="certifications.html"
+          >Certifications</a
+        >
+        <a class="text-title-md py-sm" href="case-studies.html">Case Studies</a>
+        <a
+          class="text-title-md py-sm text-primary-fixed-dim font-bold"
+          href="testimonials.html"
+          >Testimonials</a
+        >
+        <a class="text-title-md py-sm" href="blog.html">Blog</a>
+        <a class="text-title-md py-sm" href="contact.html">Contact</a>
+        <a
+          class="mt-md bg-primary-container text-on-primary-container text-center px-md py-md rounded-lg font-bold"
+          href="contact.html"
+          >Consultation</a
+        >
+      </div>
+    </div>
 
-		<!-- Heading -->
-			<div id="heading">
-				<h1>What Our Clients Say</h1>
-			</div>
+    <main class="pt-32 pb-20 px-margin max-w-7xl mx-auto">
+      <!-- Hero Section -->
+      <section class="mb-20">
+        <div class="flex flex-col md:flex-row gap-xl items-end">
+          <div class="flex-1">
+            <span
+              class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest mb-sm block"
+              >Integrity &amp; Reliability</span
+            >
+            <h1
+              class="font-display-lg text-display-lg md:text-display-lg text-on-background mb-md"
+            >
+              What Our Clients Say
+            </h1>
+            <p
+              class="font-body-lg text-body-lg text-on-surface-variant max-w-2xl"
+            >
+              Recommendations from colleagues and clients across IT
+              infrastructure, PowerShell automation, data engineering and
+              complex security compliance projects — sourced from
+              <a
+                class="text-primary-fixed-dim hover:underline"
+                href="https://www.linkedin.com/in/lukeleigh"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Luke's</a
+              >
+              and
+              <a
+                class="text-primary-fixed-dim hover:underline"
+                href="https://www.linkedin.com/in/markleigh"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Mark's</a
+              >
+              LinkedIn profiles.
+            </p>
+          </div>
+          <div class="flex-none hidden lg:block">
+            <div class="flex gap-sm">
+              <div class="w-12 h-1 bg-primary-fixed-dim opacity-20"></div>
+              <div class="w-12 h-1 bg-primary-fixed-dim"></div>
+              <div class="w-12 h-1 bg-primary-fixed-dim opacity-20"></div>
+            </div>
+          </div>
+        </div>
+      </section>
 
-		<!-- Luke Testimonials -->
-			<section class="wrapper">
-				<div class="inner">
-					<header class="special">
-						<h2>Luke Leigh &mdash; Infrastructure &amp; Automation</h2>
-						<p>Recommendations from colleagues and clients, sourced from <a href="https://www.linkedin.com/in/lukeleigh" target="_blank" rel="noopener noreferrer">Luke's LinkedIn profile</a>.</p>
-					</header>
-					<div class="testimonials">
+      <!-- Luke Section Eyebrow -->
+      <div class="mb-md flex items-baseline gap-md">
+        <span
+          class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest"
+          >Luke Leigh</span
+        >
+        <span class="font-body-sm text-body-sm text-on-surface-variant"
+          >Infrastructure &amp; Automation</span
+        >
+      </div>
 
-						<div>
-							<div class="content">
-								<div class="author">
-									<blockquote>
-										<p>"I had the pleasure of working with Luke delivering a PCI compliance project for an organisation up against a tight time deadline. Luke was extremely knowledgeable and easy to get on with. He had excellent knowledge with IT service delivery and Windows/Linux systems where his PowerShell scripting offered up innovative solutions. His ideas were pragmatic and based on actual real IT experience which is rare these days."</p>
-									</blockquote>
-								</div>
-								<p class="credit">
-									<strong>Ron Williams</strong><br />
-									Chief Executive &middot; PCI DSS QSA, Cyber Security &amp; Governance Professional &middot; <a href="https://www.linkedin.com/in/lukeleigh" target="_blank" rel="noopener noreferrer">via LinkedIn</a>
-								</p>
-							</div>
-						</div>
+      <!-- Testimonials Bento Grid -->
+      <div class="bento-grid">
+        <!-- Ron Williams — longest, col-span-8 -->
+        <div
+          class="col-span-12 md:col-span-8 glass-card rounded-xl p-xl relative overflow-hidden glow-hover"
+        >
+          <div class="testimonial-stripe"></div>
+          <span
+            class="material-symbols-outlined text-primary-fixed-dim mb-md text-4xl"
+            style="font-variation-settings: &quot;FILL&quot; 1"
+            >format_quote</span
+          >
+          <blockquote
+            class="font-headline-lg text-headline-lg text-on-background mb-xl italic leading-relaxed"
+          >
+            <p class="mb-md">
+              "I had the pleasure of working with Luke delivering a PCI
+              compliance project for an organisation up against a tight time
+              deadline.
+            </p>
+            <p class="mb-md">
+              Luke was extremely knowledgeable and easy to get on with. Luke had
+              good knowledge with networking technologies and excellent
+              knowledge with IT service delivery and Windows/Linux systems (I
+              certainly learned a few things!) where his powershell scripting
+              offered up innovative solutions. His ideas were pragmatic and
+              based on actual real IT experience which is rare these days!
+            </p>
+            <p>
+              I'd relish the chance of working with Luke again as he is a
+              professional who takes pride in his work whilst being extremely
+              friendly and helpful."
+            </p>
+          </blockquote>
+          <div class="flex items-center gap-md">
+            <div
+              class="w-16 h-16 rounded-full bg-surface-container-high border border-outline-variant flex items-center justify-center text-primary-fixed-dim avatar-initials text-xl"
+            >
+              RW
+            </div>
+            <div>
+              <div class="font-title-md text-title-md text-on-background">
+                Ron Williams
+              </div>
+              <div
+                class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-wider"
+              >
+                Chief Executive, Keynote speaker, PCI DSS QSA, Cyber Security,
+                Risk, and Governance Professional
+              </div>
+              <div
+                class="font-label-sm text-label-sm text-on-surface-variant mt-xs"
+              >
+                March 15, 2020 &middot; Luke was Ron's client
+              </div>
+              <a
+                class="font-label-sm text-label-sm text-on-surface-variant hover:text-primary-fixed-dim mt-xs inline-flex items-center gap-xs"
+                href="https://www.linkedin.com/in/lukeleigh"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span class="material-symbols-outlined text-[14px]">link</span>
+                via LinkedIn
+              </a>
+            </div>
+          </div>
+        </div>
 
-						<div>
-							<div class="content">
-								<div class="author">
-									<blockquote>
-										<p>"Luke has worked for me as an IT Manager at InsureandGo. His leadership and communication skills when working with staff are near flawless, and his knowledge and expertise in the IT arena are second to none."</p>
-									</blockquote>
-								</div>
-								<p class="credit">
-									<strong>Jair Marrugo</strong><br />
-									CEO IGS USA, IGS | Integral Group Solution &middot; <a href="https://www.linkedin.com/in/lukeleigh" target="_blank" rel="noopener noreferrer">via LinkedIn</a>
-								</p>
-							</div>
-						</div>
+        <!-- Enterprise Excellence tile — col-span-4 -->
+        <div
+          class="col-span-12 md:col-span-4 glass-card rounded-xl p-xl flex flex-col justify-center items-center text-center glow-hover border-dashed border-2 border-outline-variant"
+        >
+          <div
+            class="w-24 h-24 mb-md flex items-center justify-center bg-surface-container-low rounded-full"
+          >
+            <span
+              class="material-symbols-outlined text-primary-fixed-dim text-5xl"
+              >diamond</span
+            >
+          </div>
+          <h3 class="font-title-md text-title-md text-on-background mb-xs">
+            Enterprise Excellence
+          </h3>
+          <p class="font-body-sm text-body-sm text-on-surface-variant">
+            Mission-critical infrastructure, compliance and data engineering
+            trusted by organisations from InsureandGo and Seetec to Swarovski.
+          </p>
+        </div>
 
-						<div>
-							<div class="content">
-								<div class="author">
-									<blockquote>
-										<p>"I have known Luke for approximately 22 years and I have had the pleasure of working with him both at InsureandGo and Seetec Medical Systems. In all instances Luke has been a consummate professional and maintained a reliable and formidable understanding of business processes and current technology."</p>
-									</blockquote>
-								</div>
-								<p class="credit">
-									<strong>Scott Pigram</strong><br />
-									IT Manager, Sternberg Reed LLP &middot; <a href="https://www.linkedin.com/in/lukeleigh" target="_blank" rel="noopener noreferrer">via LinkedIn</a>
-								</p>
-							</div>
-						</div>
+        <!-- Jair Marrugo — col-span-6 -->
+        <div
+          class="col-span-12 md:col-span-6 glass-card rounded-xl p-xl relative overflow-hidden glow-hover"
+        >
+          <div class="testimonial-stripe"></div>
+          <span
+            class="material-symbols-outlined text-primary-fixed-dim mb-md text-4xl"
+            style="font-variation-settings: &quot;FILL&quot; 1"
+            >format_quote</span
+          >
+          <blockquote
+            class="font-body-lg text-body-lg text-on-background mb-xl italic leading-relaxed"
+          >
+            "Luke has worked for me as an IT Manager at InsureandGo. His
+            leadership and communication skills when working with staff are near
+            flawless, and his knowledge and expertise in the IT arena are second
+            to none."
+          </blockquote>
+          <div class="flex items-center gap-md mt-auto">
+            <div
+              class="w-12 h-12 rounded-full bg-surface-container-high border border-outline-variant flex items-center justify-center text-primary-fixed-dim avatar-initials"
+            >
+              JM
+            </div>
+            <div>
+              <div class="font-title-md text-title-md text-on-background">
+                JAIR MARRUGO
+              </div>
+              <div class="font-label-md text-label-md text-primary-fixed-dim">
+                CEO IGS USA at IGS | Integral Group Solution
+              </div>
+              <div
+                class="font-label-sm text-label-sm text-on-surface-variant mt-xs"
+              >
+                June 5, 2018 &middot; JAIR was senior to Luke but didn't manage
+                Luke directly
+              </div>
+              <a
+                class="font-label-sm text-label-sm text-on-surface-variant hover:text-primary-fixed-dim mt-xs inline-flex items-center gap-xs"
+                href="https://www.linkedin.com/in/lukeleigh"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span class="material-symbols-outlined text-[14px]">link</span>
+                via LinkedIn
+              </a>
+            </div>
+          </div>
+        </div>
 
-						<div>
-							<div class="content">
-								<div class="author">
-									<blockquote>
-										<p>"Luke has a fantastically broad and in-depth knowledge of both Windows-related IT infrastructure and all aspects of network architecture. Luke was instrumental to InsureandGo attaining PCI compliance. If he doesn't know something at 9:00am, he'll have it scripted and be able to explain to you how it works by 5:00pm!"</p>
-									</blockquote>
-								</div>
-								<p class="credit">
-									<strong>Rob Green</strong><br />
-									Lead Software Engineer &amp; Owner, Rob Green Engineering Ltd &middot; <a href="https://www.linkedin.com/in/lukeleigh" target="_blank" rel="noopener noreferrer">via LinkedIn</a>
-								</p>
-							</div>
-						</div>
+        <!-- Scott Pigram — col-span-6 -->
+        <div
+          class="col-span-12 md:col-span-6 glass-card rounded-xl p-xl relative overflow-hidden glow-hover"
+        >
+          <div class="testimonial-stripe"></div>
+          <span
+            class="material-symbols-outlined text-primary-fixed-dim mb-md text-4xl"
+            style="font-variation-settings: &quot;FILL&quot; 1"
+            >format_quote</span
+          >
+          <blockquote
+            class="font-body-lg text-body-lg text-on-background mb-xl italic leading-relaxed"
+          >
+            <p class="mb-md">
+              "I have known Luke for approximately 22 years and I have had the
+              pleasure of working with him both at InsureandGo and Seetec
+              Medical Systems some 13 years ago. We have also undertaken private
+              projects working together on installations for small businesses.
+            </p>
+            <p class="mb-md">
+              In all instances Luke has been a consummate professional and
+              maintained a reliable and formidable understanding of business
+              processes and current technology. We have worked together on many
+              projects during this time and we have always been able to meet the
+              expected and unexpected deadlines required by the business.
+            </p>
+            <p class="mb-md">
+              Unfortunately, due to circumstances outside our control, we are no
+              longer in partnership but I would not hesitate to work alongside
+              Luke in the future.
+            </p>
+            <p class="mb-md">
+              When working with Luke, Luke took charge of the WAN infrastructure
+              and 3rd Line support ensuring that all network services were
+              maintained to the highest standards. Luke was involved and ran the
+              majority of the projects carried out in-house, some of which
+              included:
+            </p>
+            <ul
+              class="list-none space-y-1 mb-md not-italic font-body-md text-body-md"
+            >
+              <li>
+                &#10148; Design network segmentation solution, replacing
+                original flat network design and implementing secure VLAN
+                restrictions for servers, workstations
+              </li>
+              <li>
+                &#10148; Implementation of PCI Compliant network architecture,
+                maintaining system availability to meet business requirements
+              </li>
+              <li>
+                &#10148; Team Lead for infrastructure changes to meet compliance
+                requirements
+              </li>
+              <li>
+                &#10148; Liaise with 3rd Party QSA during PCI Compliance
+                Assessments
+              </li>
+              <li>&#10148; Planning of Data Centre Migration</li>
+              <li>
+                &#10148; Provision access (Physical/Virtual) for penetration
+                testing teams
+              </li>
+              <li>&#10148; Document internal policies</li>
+              <li>
+                &#10148; Develop internal access solutions for infrastructure
+                maintaining security and compliance levels to meet with PCI
+                compliance
+              </li>
+              <li>
+                &#10148; Liaise with the Management Team on new business
+                development solutions and infrastructure expansion
+              </li>
+              <li>&#10148; Public DNS Migration</li>
+              <li>
+                &#10148; Redesign architecture of Public DNS Solution whilst
+                ensuring no down-time
+              </li>
+              <li>
+                &#10148; Design secure home-worker solution for claims
+                department
+              </li>
+              <li>
+                &#10148; Provision access from Global WAN for USA, Australia and
+                UK Development Teams
+              </li>
+              <li>
+                &#10148; Mentor UK IT Support Teams providing training and
+                leadership for all staff
+              </li>
+              <li>
+                &#10148; Provision of Out of Hours training for UK support teams
+              </li>
+              <li>&#10148; Team Lead for Incident Response</li>
+            </ul>
+            <p class="mb-md">
+              There were also a lot more projects that I was not involved in
+              that Luke exceeded at. Although Luke is very technical he is able
+              to articulate the technical into a level of understanding that the
+              colleague he is dealing with will understand. Luke always took the
+              time to explain a situation and everyone knew what their role was
+              in the projects. This also spilled into the day to day working of
+              the office which made everyone feel more confident, supported,
+              with what they were doing and what was expected of them.
+            </p>
+            <p>Kind Regards,<br />Scott Pigram"</p>
+          </blockquote>
+          <div class="flex items-center gap-md mt-auto">
+            <div
+              class="w-12 h-12 rounded-full bg-surface-container-high border border-outline-variant flex items-center justify-center text-primary-fixed-dim avatar-initials"
+            >
+              SP
+            </div>
+            <div>
+              <div class="font-title-md text-title-md text-on-background">
+                Scott Pigram
+              </div>
+              <div class="font-label-md text-label-md text-primary-fixed-dim">
+                IT Manager at Sternberg Reed LLP
+              </div>
+              <div
+                class="font-label-sm text-label-sm text-on-surface-variant mt-xs"
+              >
+                June 5, 2018 &middot; Luke was senior to Scott but didn't manage
+                Scott directly
+              </div>
+              <a
+                class="font-label-sm text-label-sm text-on-surface-variant hover:text-primary-fixed-dim mt-xs inline-flex items-center gap-xs"
+                href="https://www.linkedin.com/in/lukeleigh"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span class="material-symbols-outlined text-[14px]">link</span>
+                via LinkedIn
+              </a>
+            </div>
+          </div>
+        </div>
 
-					</div>
-				</div>
-			</section>
+        <!-- Rob Green — col-span-12 -->
+        <div
+          class="col-span-12 glass-card rounded-xl p-xl relative overflow-hidden glow-hover"
+        >
+          <div class="testimonial-stripe"></div>
+          <span
+            class="material-symbols-outlined text-primary-fixed-dim mb-md text-4xl"
+            style="font-variation-settings: &quot;FILL&quot; 1"
+            >format_quote</span
+          >
+          <blockquote
+            class="font-body-lg text-body-lg text-on-background mb-xl italic leading-relaxed"
+          >
+            <p class="mb-md">
+              "Throughout my time at InsureandGo as both a software engineer and
+              development team manager, Luke was always my first point of
+              contact for help with anything relating to the company's
+              technology infrastructure. Luke has a fantastically broad and
+              in-depth knowledge of both Windows-related IT infrastructure and
+              all aspects of network architecture.
+            </p>
+            <p>
+              Luke was instrumental to InsureandGo attaining PCI compliance. If
+              he doesn't know something at 9:00am, he'll have it scripted and be
+              able to explain to you how it works by 5:00pm! Truly a pleasure to
+              work with and I hope our professional paths cross again some time
+              in the future."
+            </p>
+          </blockquote>
+          <div class="flex items-center gap-md mt-auto">
+            <div
+              class="w-12 h-12 rounded-full bg-surface-container-high border border-outline-variant flex items-center justify-center text-primary-fixed-dim avatar-initials"
+            >
+              RG
+            </div>
+            <div>
+              <div class="font-title-md text-title-md text-on-background">
+                Rob Green
+              </div>
+              <div class="font-label-md text-label-md text-primary-fixed-dim">
+                Lead Software Engineer &amp; Owner at Rob Green Engineering Ltd
+              </div>
+              <div
+                class="font-label-sm text-label-sm text-on-surface-variant mt-xs"
+              >
+                June 4, 2018 &middot; Rob worked with Luke but on different
+                teams
+              </div>
+              <a
+                class="font-label-sm text-label-sm text-on-surface-variant hover:text-primary-fixed-dim mt-xs inline-flex items-center gap-xs"
+                href="https://www.linkedin.com/in/lukeleigh"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span class="material-symbols-outlined text-[14px]">link</span>
+                via LinkedIn
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
 
-		<!-- Mark Testimonials -->
-			<section class="wrapper">
-				<div class="inner">
-					<header class="special">
-						<h2>Mark Leigh &mdash; Data Engineering &amp; Security</h2>
-						<p>Recommendations from colleagues and clients, sourced from <a href="https://www.linkedin.com/in/markleigh" target="_blank" rel="noopener noreferrer">Mark's LinkedIn profile</a>.</p>
-					</header>
-					<div class="testimonials">
+      <!-- Mark Section Eyebrow -->
+      <div class="mt-20 mb-md flex items-baseline gap-md">
+        <span
+          class="font-label-md text-label-md text-primary-fixed-dim uppercase tracking-widest"
+          >Mark Leigh</span
+        >
+        <span class="font-body-sm text-body-sm text-on-surface-variant"
+          >Data Engineering &amp; Security</span
+        >
+      </div>
 
-						<div>
-							<div class="content">
-								<div class="author">
-									<blockquote>
-										<p>"I have worked together with Mark on several projects as part of the Data Engineering team at Swarovski. Mark is a real team player and an experienced project leader who is able to provide guidance and manage multi-stakeholder environments. He is very versatile and able to master new technologies rapidly. I would be very happy to work with him any time again."</p>
-									</blockquote>
-								</div>
-								<p class="credit">
-									<strong>Martin I.</strong><br />
-									Data Science &amp; Data Engineering &middot; <a href="https://www.linkedin.com/in/markleigh" target="_blank" rel="noopener noreferrer">via LinkedIn</a>
-								</p>
-							</div>
-						</div>
+      <div class="bento-grid">
+        <!-- Martin I. — col-span-6 -->
+        <div
+          class="col-span-12 md:col-span-6 glass-card rounded-xl p-xl relative overflow-hidden glow-hover"
+        >
+          <div class="testimonial-stripe"></div>
+          <span
+            class="material-symbols-outlined text-primary-fixed-dim mb-md text-4xl"
+            style="font-variation-settings: &quot;FILL&quot; 1"
+            >format_quote</span
+          >
+          <blockquote
+            class="font-body-lg text-body-lg text-on-background mb-xl italic leading-relaxed"
+          >
+            "I have worked together with Mark on several projects as part of the
+            Data Engineering team at Swarovski. Mark is a real team player and I
+            very much enjoyed working with him. Not only is he dedicated and
+            hard working towards a common goal, he is also an experienced
+            project leader who is able to provide guidance and manage
+            multi-stakeholder environments. Also, based on his experience, he is
+            very versatile and able to master new technologies rapidly. I would
+            be very happy to work with him any time again."
+          </blockquote>
+          <div class="flex items-center gap-md mt-auto">
+            <div
+              class="w-12 h-12 rounded-full bg-surface-container-high border border-outline-variant flex items-center justify-center text-primary-fixed-dim avatar-initials"
+            >
+              MI
+            </div>
+            <div>
+              <div class="font-title-md text-title-md text-on-background">
+                Martin I.
+              </div>
+              <div class="font-label-md text-label-md text-primary-fixed-dim">
+                Data Science &amp; Data Engineering
+              </div>
+              <div
+                class="font-label-sm text-label-sm text-on-surface-variant mt-xs"
+              >
+                December 11, 2021
+              </div>
+              <a
+                class="font-label-sm text-label-sm text-on-surface-variant hover:text-primary-fixed-dim mt-xs inline-flex items-center gap-xs"
+                href="https://www.linkedin.com/in/markleigh"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span class="material-symbols-outlined text-[14px]">link</span>
+                via LinkedIn
+              </a>
+            </div>
+          </div>
+        </div>
 
-						<div>
-							<div class="content">
-								<div class="author">
-									<blockquote>
-										<p>"I worked with Mark on a complex financial reporting project. His attention to detail is second to none. He was able to articulate clearly the development enabling me to successfully test. He was open to suggestions, able to follow ideas through and clearly explain why something would or wouldn't work. He was supportive of test and would point me in a new direction if new development warranted it."</p>
-									</blockquote>
-								</div>
-								<p class="credit">
-									<strong>Gary Burgess (DipAF)</strong><br />
-									ISTQB Certified Tester Foundation &middot; <a href="https://www.linkedin.com/in/markleigh" target="_blank" rel="noopener noreferrer">via LinkedIn</a>
-								</p>
-							</div>
-						</div>
+        <!-- Gary Burgess — col-span-6 -->
+        <div
+          class="col-span-12 md:col-span-6 glass-card rounded-xl p-xl relative overflow-hidden glow-hover"
+        >
+          <div class="testimonial-stripe"></div>
+          <span
+            class="material-symbols-outlined text-primary-fixed-dim mb-md text-4xl"
+            style="font-variation-settings: &quot;FILL&quot; 1"
+            >format_quote</span
+          >
+          <blockquote
+            class="font-body-lg text-body-lg text-on-background mb-xl italic leading-relaxed"
+          >
+            "I worked with Mark on a complex financial reporting project. His
+            attention to detail is second to none. He was able to articulate
+            clearly the development enabling me to successfully test. He would
+            make himself available for all my questions, travelling to meet me
+            where necessary to spend quality time in analysis meetings. He was
+            open to suggestions, was able to follow the idea through to see
+            whether it would work and clearly explain why it couldn't. He was
+            supportive of test and would point me in a new direction if new
+            development warranted it, expressing with examples what he needed
+            test to cover. We have remained friends after the project and he has
+            been someone I could talk to about work decisions. I've also enjoyed
+            our football chats."
+          </blockquote>
+          <div class="flex items-center gap-md mt-auto">
+            <div
+              class="w-12 h-12 rounded-full bg-surface-container-high border border-outline-variant flex items-center justify-center text-primary-fixed-dim avatar-initials"
+            >
+              GB
+            </div>
+            <div>
+              <div class="font-title-md text-title-md text-on-background">
+                Gary Burgess (DipAF)
+              </div>
+              <div class="font-label-md text-label-md text-primary-fixed-dim">
+                Professional bug squasher, data whisperer, and occasional coffee
+                consumer
+              </div>
+              <div
+                class="font-label-sm text-label-sm text-on-surface-variant mt-xs"
+              >
+                August 12, 2021 &middot; Gary worked with Mark on the same team
+              </div>
+              <a
+                class="font-label-sm text-label-sm text-on-surface-variant hover:text-primary-fixed-dim mt-xs inline-flex items-center gap-xs"
+                href="https://www.linkedin.com/in/markleigh"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span class="material-symbols-outlined text-[14px]">link</span>
+                via LinkedIn
+              </a>
+            </div>
+          </div>
+        </div>
 
-					</div>
-				</div>
-			</section>
+        <!-- Stats Card — col-span-12 -->
+        <div
+          class="col-span-12 glass-card rounded-xl p-lg grid grid-cols-2 md:grid-cols-4 gap-lg mt-md"
+        >
+          <div class="text-center md:border-r md:border-outline-variant">
+            <div class="font-display-lg text-display-lg text-primary-fixed-dim">
+              50+
+            </div>
+            <div
+              class="font-label-sm text-label-sm uppercase text-on-surface-variant"
+            >
+              Years Combined Experience
+            </div>
+          </div>
+          <div class="text-center md:border-r md:border-outline-variant">
+            <div class="font-display-lg text-display-lg text-primary-fixed-dim">
+              25+
+            </div>
+            <div
+              class="font-label-sm text-label-sm uppercase text-on-surface-variant"
+            >
+              Years Luke — Infra &amp; Automation
+            </div>
+          </div>
+          <div class="text-center md:border-r md:border-outline-variant">
+            <div class="font-display-lg text-display-lg text-primary-fixed-dim">
+              20+
+            </div>
+            <div
+              class="font-label-sm text-label-sm uppercase text-on-surface-variant"
+            >
+              Years Mark — Data &amp; Security
+            </div>
+          </div>
+          <div class="text-center">
+            <div class="font-display-lg text-display-lg text-primary-fixed-dim">
+              100%
+            </div>
+            <div
+              class="font-label-sm text-label-sm uppercase text-on-surface-variant"
+            >
+              Client Retention Record
+            </div>
+          </div>
+        </div>
+      </div>
 
-		<!-- Leave a recommendation -->
-			<section id="cta" class="wrapper">
-				<div class="inner">
-					<h2>Worked with us?</h2>
-					<p>If we have worked together and you would like to leave a recommendation, we would really appreciate it.</p>
-					<a href="https://www.linkedin.com/in/lukeleigh" target="_blank" rel="noopener noreferrer" class="button fit small">Recommend Luke on LinkedIn</a>
-					&nbsp;&nbsp;
-					<a href="https://www.linkedin.com/in/markleigh" target="_blank" rel="noopener noreferrer" class="button fit small">Recommend Mark on LinkedIn</a>
-				</div>
-			</section>
+      <!-- Call to Action -->
+      <section
+        class="mt-20 glass-card rounded-xl p-xl overflow-hidden relative"
+      >
+        <div class="relative z-10">
+          <h2
+            class="font-headline-lg text-headline-lg text-on-background mb-md"
+          >
+            Worked with us?
+          </h2>
+          <p
+            class="font-body-lg text-body-lg text-on-surface-variant max-w-xl mb-xl"
+          >
+            If we have worked together and you would like to leave a
+            recommendation, we would really appreciate it. Endorsements on
+            LinkedIn help us continue to bring the same expertise and
+            reliability to new clients.
+          </p>
+          <div class="flex flex-wrap gap-md">
+            <a
+              class="bg-primary-container text-on-primary-container px-xl py-md rounded-lg font-bold flex items-center gap-sm glow-hover transition-all"
+              href="https://www.linkedin.com/in/lukeleigh"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span>Recommend Luke on LinkedIn</span>
+              <span class="material-symbols-outlined">arrow_forward</span>
+            </a>
+            <a
+              class="border border-outline-variant text-on-surface px-xl py-md rounded-lg font-bold hover:bg-surface-variant transition-all flex items-center gap-sm"
+              href="https://www.linkedin.com/in/markleigh"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span>Recommend Mark on LinkedIn</span>
+              <span class="material-symbols-outlined">open_in_new</span>
+            </a>
+          </div>
+        </div>
+      </section>
+    </main>
 
-		<!-- Footer -->
-			<footer id="footer">
-				<div class="inner">
-					<div class="content">
-						<section>
-							<h3>Leigh Services</h3>
-							<p>Expert IT Infrastructure, Automation and Data Engineering consulting based in Southend-on-Sea, Essex. Serving clients across the UK and internationally.</p>
-							<p>63 Archer Avenue, Southend on Sea, Essex SS2 4QU</p>
-						</section>
-						<section>
-							<h4>Services</h4>
-							<ul class="alt">
-								<li><a href="services.html#it-infrastructure">IT Infrastructure</a></li>
-								<li><a href="services.html#powershell-automation">PowerShell &amp; Automation</a></li>
-								<li><a href="services.html#cloud-solutions">Cloud Solutions</a></li>
-								<li><a href="services.html#data-engineering">Data Engineering</a></li>
-								<li><a href="services.html#security-compliance">Security &amp; Compliance</a></li>
-								<li><a href="services.html#devsecops">DevSecOps</a></li>
-							</ul>
-						</section>
-						<section>
-							<h4>Connect</h4>
-							<ul class="plain">
-								<li><a href="https://www.linkedin.com/in/lukeleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>Luke on LinkedIn</a></li>
-								<li><a href="https://www.linkedin.com/in/markleigh" target="_blank" rel="noopener noreferrer"><i class="icon fa-linkedin">&nbsp;</i>Mark on LinkedIn</a></li>
-								<li><a href="https://github.com/BanterBoy" target="_blank" rel="noopener noreferrer"><i class="icon fa-github">&nbsp;</i>GitHub (BanterBoy)</a></li>
-								<li><a href="https://blog.lukeleigh.com" target="_blank" rel="noopener noreferrer"><i class="icon fa-rss">&nbsp;</i>Luke's Blog</a></li>
-							</ul>
-						</section>
-					</div>
-					<div class="copyright">
-						&copy; 2024&ndash;2026 Leigh IT Services Ltd. All rights reserved.
-					</div>
-				</div>
-			</footer>
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
-
-	</body>
+    <!-- Footer -->
+    <footer class="bg-surface-container-lowest border-t border-outline-variant">
+      <div
+        class="grid grid-cols-1 md:grid-cols-4 gap-xl px-lg py-xl max-w-7xl mx-auto"
+      >
+        <div>
+          <div
+            class="font-title-md text-title-md font-bold text-primary-fixed-dim mb-md"
+          >
+            Leigh Services
+          </div>
+          <p class="font-body-sm text-body-sm text-on-surface-variant mb-lg">
+            Expert IT Infrastructure, Automation and Data Engineering consulting
+            based in Southend-on-Sea, Essex. Serving clients across the UK and
+            internationally.
+          </p>
+          <div class="text-on-surface-variant font-body-sm">
+            63 Archer Avenue, Southend on Sea, Essex SS2 4QU
+          </div>
+        </div>
+        <div>
+          <div
+            class="font-label-md text-label-md font-bold text-on-background mb-md uppercase tracking-wider"
+          >
+            Services
+          </div>
+          <ul class="space-y-sm">
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="services.html#it-infrastructure"
+                >IT Infrastructure</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="services.html#powershell-automation"
+                >PowerShell &amp; Automation</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="services.html#cloud-solutions"
+                >Cloud Solutions</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="services.html#data-engineering"
+                >Data Engineering</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="services.html#security-compliance"
+                >Security &amp; Compliance</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="services.html#devsecops"
+                >DevSecOps</a
+              >
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            class="font-label-md text-label-md font-bold text-on-background mb-md uppercase tracking-wider"
+          >
+            Company
+          </div>
+          <ul class="space-y-sm">
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="team.html"
+                >Meet the Team</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="certifications.html"
+                >Certifications</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="case-studies.html"
+                >Case Studies</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-primary-fixed-dim font-bold"
+                href="testimonials.html"
+                >Testimonials</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="blog.html"
+                >Blog</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors"
+                href="contact.html"
+                >Contact</a
+              >
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            class="font-label-md text-label-md font-bold text-on-background mb-md uppercase tracking-wider"
+          >
+            Connect
+          </div>
+          <ul class="space-y-sm">
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors flex items-center gap-xs"
+                href="https://www.linkedin.com/in/lukeleigh"
+                target="_blank"
+                rel="noopener noreferrer"
+                ><span class="material-symbols-outlined text-sm">link</span>
+                Luke on LinkedIn</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors flex items-center gap-xs"
+                href="https://www.linkedin.com/in/markleigh"
+                target="_blank"
+                rel="noopener noreferrer"
+                ><span class="material-symbols-outlined text-sm">link</span>
+                Mark on LinkedIn</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors flex items-center gap-xs"
+                href="https://github.com/BanterBoy"
+                target="_blank"
+                rel="noopener noreferrer"
+                ><span class="material-symbols-outlined text-sm">terminal</span>
+                GitHub (BanterBoy)</a
+              >
+            </li>
+            <li>
+              <a
+                class="font-body-sm text-body-sm text-on-surface-variant hover:text-primary transition-colors flex items-center gap-xs"
+                href="https://blog.lukeleigh.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                ><span class="material-symbols-outlined text-sm">rss_feed</span>
+                Luke's Blog</a
+              >
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div
+        class="max-w-7xl mx-auto px-lg py-md border-t border-outline-variant flex flex-col md:flex-row justify-between items-center gap-md"
+      >
+        <div class="font-body-sm text-body-sm text-on-surface-variant">
+          © 2024–2026 Leigh IT Services Ltd. All rights reserved.
+        </div>
+      </div>
+    </footer>
+  </body>
 </html>


### PR DESCRIPTION
Promotes the Stitch-design rebuild from staging to production (leigh-services.com).

## What's included

Full visual redesign of all 8 site pages on Tailwind CDN + Material 3 dark palette (Geist + JetBrains Mono + Material Symbols), with every piece of original copy preserved verbatim.

| Page | Content |
|------|---------|
| index.html | Hero + status badge + terminal mockup, 6-tile bento, owners section |
| services.html | 6 service sections with in-page anchors |
| team.html | Luke (bio + 12 skill chips + 8 roles) + Mark (bio + 12 skill chips + 6 roles + 3 certs) |
| certifications.html | 7 certifications (M365/Azure, GCP, PowerShell Gallery, GitHub OSS, Security+, CREST CPSA in-progress, BSc) |
| case-studies.html | 6 case studies (Mapfre PCI DSS, Swarovski SAS->GCP, Ventrica, Carpetright, FINREP, Solopress) |
| testimonials.html | 6 verbatim LinkedIn testimonials with dates + relationships |
| blog.html | 9 real curated articles from blog.lukeleigh.com |
| contact.html | Formspree form + Google Maps embed |

## Verification

- Already merged and validated on staging (PR #12 passed checks)
- Standardised 8-item nav across all pages (desktop + mobile) with Consultation CTA
- All external links use target=_blank rel=noopener noreferrer
- No email addresses or phone numbers on any public page
- assets/css/main.css unchanged (CI owns it; new pages are Tailwind-based)
- Local Stitch reference folder gitignored

## Post-merge

After production deploy completes, tag release as v1.2026.06.19.